### PR TITLE
FreeBSD uses non-GNU coreutils

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -492,6 +492,7 @@ if [ "x$DEBUG_BUILD_OPTIONS" = "x" ] ; then
 
     case "$OSTYPE" in
       darwin*)  PERM="+111" ;;
+      freebsd*) PERM="+111" ;;
       *)        PERM="/111" ;;
     esac
 


### PR DESCRIPTION
This fixes the build on FreeBSD for using `find`.