### PR TITLE
add c++ to gcc-first for pthread bindings

### DIFF
--- a/build-toolchain.sh
+++ b/build-toolchain.sh
@@ -327,7 +327,7 @@ $SRCDIR/$GCC/configure --target=$TARGET \
     --mandir=$INSTALLDIR_NATIVE_DOC/man \
     --htmldir=$INSTALLDIR_NATIVE_DOC/html \
     --pdfdir=$INSTALLDIR_NATIVE_DOC/pdf \
-    --enable-languages=c \
+    --enable-languages=c,c++ \
     --disable-decimal-float \
     --disable-libffi \
     --disable-libgomp \


### PR DESCRIPTION
This should be a temporary workaround until pthread-embedded is POSIX compliant in regards to pthread_t.