### PR TITLE
Patch zlib so that it doesn't try to build programs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ function(toolchain_deps toolchain_deps_dir toolchain_install_dir toolchain_suffi
         URL http://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.xz
         URL_HASH SHA256=4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066
         DOWNLOAD_DIR ${DOWNLOAD_DIR}
+        PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/zlib.patch
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${toolchain_deps_dir}
         ${toolchain_cmake_args}
         )

--- a/patches/zlib.patch
+++ b/patches/zlib.patch
@@ -1,0 +1,29 @@
+diff -r -u zlib-1.2.11/CMakeLists.txt zlib-1.2.11-patched/CMakeLists.txt
+--- zlib-1.2.11/CMakeLists.txt	2017-01-15 17:29:40.000000000 +0000
++++ zlib-1.2.11-patched/CMakeLists.txt	2018-01-07 18:11:41.296650376 +0000
+@@ -225,25 +225,3 @@
+ if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+ endif()
+-
+-#============================================================================
+-# Example binaries
+-#============================================================================
+-
+-add_executable(example test/example.c)
+-target_link_libraries(example zlib)
+-add_test(example example)
+-
+-add_executable(minigzip test/minigzip.c)
+-target_link_libraries(minigzip zlib)
+-
+-if(HAVE_OFF64_T)
+-    add_executable(example64 test/example.c)
+-    target_link_libraries(example64 zlib)
+-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+-    add_test(example64 example64)
+-
+-    add_executable(minigzip64 test/minigzip.c)
+-    target_link_libraries(minigzip64 zlib)
+-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+-endif()


### PR DESCRIPTION
Building programs breaks the build when we try to shove -static through
CC/CXX env vars.