### PR TITLE
Define NO_IMPLICIT_EXTERN_C when building GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,9 +405,12 @@ list(APPEND pthread_tools
     AR=${binutils_prefix}-ar
     )
 
+# Prevent GCC wrapping system includes in extern "C" (modern systems should define this)
+set(extra_cflags -DNO_IMPLICIT_EXTERN_C)
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     # GCC on OSX (Clang in diguise) needs more bracket nesting depth to compile gcc
-    set(extra_cflags -fbracket-depth=512)
+	list(APPEND extra_cflags -fbracket-depth=512)
 endif()
 
 # Common gcc configure options


### PR DESCRIPTION
Many developers prefer to define library include paths using -isystem in
order to suppress warnings from external code and reduce noise when
compiling.

Without this preprocessor definition, GCC will quietly wrap all C++ code
found in system include paths with the 'extern "C" {}' construct. This
will break C++ features that rely on name mangling such as templates.

Modern systems (e.g. Linux x86) have this definition specified in their GCC
config headers, but embedded ARM does not. We should be able to safely
enable this definition for PS Vita.

References:

  * https://gcc.gnu.org/onlinedocs/gccint/Misc.html#index-NO_005fIMPLICIT_005fEXTERN_005fC
  * https://gcc.gnu.org/ml/gcc-patches/2012-06/msg01151.html
  * https://bugs.launchpad.net/gcc-arm-embedded/+bug/1698539