### PR TITLE
Fix osx build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,11 +431,11 @@ list(APPEND pthread_tools
     )
 
 # Prevent GCC wrapping system includes in extern "C" (modern systems should define this)
-set(extra_cflags -DNO_IMPLICIT_EXTERN_C)
+set(extra_cppflags -DNO_IMPLICIT_EXTERN_C)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    # GCC on OSX (Clang in diguise) needs more bracket nesting depth to compile gcc
-	list(APPEND extra_cflags -fbracket-depth=512)
+  # GCC on OSX (Clang in diguise) needs more bracket nesting depth to compile gcc
+	set(extra_cflags -fbracket-depth=512)
 endif()
 
 # Common gcc configure options
@@ -475,7 +475,7 @@ ExternalProject_add(gcc-base
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
     PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc-6.patch
-    CONFIGURE_COMMAND CFLAGS=${extra_cflags} CXXFLAGS=${extra_cflags} ${compiler_flags}
+    CONFIGURE_COMMAND CFLAGS=${extra_cflags} CXXFLAGS=${extra_cflags} CPPFLAGS=${extra_cppflags} ${compiler_flags}
     ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}
     # compile a native compiler so keep host == build
@@ -563,7 +563,7 @@ if(CMAKE_TOOLCHAIN_FILE)
         URL_HASH ${GCC_HASH}
         DOWNLOAD_DIR ${DOWNLOAD_DIR}
         PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc-6.patch
-        CONFIGURE_COMMAND CFLAGS=${extra_cflags} CXXFLAGS=${extra_cflags} ${compiler_flags} ${toolchain_tools}
+        CONFIGURE_COMMAND CFLAGS=${extra_cflags} CXXFLAGS=${extra_cflags} CPPFLAGS=${extra_cppflags} ${compiler_flags} ${toolchain_tools}
         ${wrapper_command} <SOURCE_DIR>/configure
         --build=${build_native}
         # compile a native compiler so keep host == build
@@ -616,8 +616,8 @@ ExternalProject_add(gcc-final
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
     PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc-6.patch
-    CONFIGURE_COMMAND CFLAGS=${extra_cflags}
-    CXXFLAGS=${extra_cflags} ${compiler_flags} ${toolchain_tools} ${compiler_target_tools}
+    CONFIGURE_COMMAND CFLAGS=${extra_cflags} CXXFLAGS=${extra_cflags} CPPFLAGS=${extra_cppflags}
+    ${compiler_flags} ${toolchain_tools} ${compiler_target_tools}
     ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}
     --host=${host_native}


### PR DESCRIPTION
The osx build has been broken since a344880a5193ad5d9b60232ed8d77faa3bb0bbbd (See vitasdk/autobuilds#12 too). The changes introduced on the referenced commit makes the `$extra_cflags` variable on the osx version contain a list with two flags. This list is then used to define environment variables for the configure command without escaping the whitespace or quoting its value.

Take in mind that this won't make the autobuilds work again just yet because gdb won't compile with xcode 8 but it compiles fine with xcode 9.4 as you can see here https://travis-ci.com/planas/autobuilds/builds/95935818.