### PR TITLE
Use a mirror download for `libelf`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ function(toolchain_deps toolchain_deps_dir toolchain_install_dir toolchain_suffi
         )
 
     ExternalProject_add(libelf${suffix}
-        URL http://www.mr511.de/software/libelf-${LIBELF_VERSION}.tar.gz
+        URL https://fossies.org/linux/misc/old/libelf-${LIBELF_VERSION}.tar.gz
         URL_HASH ${LIBELF_HASH}
         DOWNLOAD_DIR ${DOWNLOAD_DIR}
         PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/libelf.patch


### PR DESCRIPTION
Hi !

With `mr511.de` down, autobuilds are failing. This PR replaces the link to the `libelf` archive with another mirror (`fossies.org`). 

Hopefully fixes vitasdk/autobuilds#14.