### PR TITLE
Fix crash with using C++ thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,7 +622,9 @@ ExternalProject_add(gcc-final
     URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+    PATCH_COMMAND
+        patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+        && patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0002-gcc-9-pthread.patch
     CONFIGURE_COMMAND ${compiler_flags} ${toolchain_tools} ${compiler_target_tools}
     ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}

--- a/patches/gcc/0002-gcc-9-pthread.patch
+++ b/patches/gcc/0002-gcc-9-pthread.patch
@@ -1,0 +1,13 @@
+diff -uHNr gcc-9.1.0.orig/libgcc/gthr-posix.h gcc-9.1.0/libgcc/gthr-posix.h
+--- gcc-9.1.0.orig/libgcc/gthr-posix.h	2020-04-16 04:40:41.864017273 +0900
++++ gcc-9.1.0/libgcc/gthr-posix.h	2020-05-01 06:31:36.844109263 +0900
+@@ -29,6 +29,9 @@
+ /* POSIX threads specific definitions.
+    Easy, since the interface is just one-to-one mapping.  */
+ 
++#undef GTHREAD_USE_WEAK
++#define GTHREAD_USE_WEAK 0
++
+ #define __GTHREADS 1
+ #define __GTHREADS_CXX0X 1
+ 


### PR DESCRIPTION
disable `GTHREAD_USE_WEAK` flag like lynx, darwin, cygwin and
others.

test sample;
```
std::once_flag flag;

void thread() {
    try {
        std::call_once(flag, [](){
        });
    } catch (...) {
    }
}

int main(int argc, char *argv[]) {
    psvDebugScreenInit();
    printf("testing try-catch\n");

    if (!pthread_init()) {
        printf("thread init error\n");
    }

    printf("run thread\n");

    std::thread t{thread};

    printf("try join thread\n");

    try {
        t.join();
    } catch (...) {
        printf("try join thread err\n");
    }

    printf("end thread\n");
    sceKernelDelayThread(10000*1000);
    return 0;
}

```

disassemble of before patch;
```
0000d88c <_ZNSt6thread4joinEv>:
    d88c:       b510            push    {r4, lr}
    d88e:       4604            mov     r4, r0
    d890:       6800            ldr     r0, [r0, #0]
    d892:       b128            cbz     r0, d8a0 <_ZNSt6thread4joinEv+0x14>
    d894:       2100            movs    r1, #0
    d896:       f3af 8000       nop.w
    d89a:       b910            cbnz    r0, d8a2 <_ZNSt6thread4joinEv+0x16>
    d89c:       6020            str     r0, [r4, #0]
    d89e:       bd10            pop     {r4, pc}
    d8a0:       2016            movs    r0, #22
    d8a2:       f7fa fbcd       bl      8040 <_ZSt20__throw_system_errori>
    d8a6:       bf00            nop
```

when I get the disassemble code of the output, it doesn't have
`pthread_join`.
then process would call `throw_system_error`.

more bad things, process will occur crash whether wrapping try-catch block
or not.
crash with try-catch case would happen at the end of the application,
`thread` try to call the `_kill_r`, then occurs crash.

disassemble of after patch;
```
0000e69c <_ZNSt6thread4joinEv>:
    e69c:       b510            push    {r4, lr}
    e69e:       4604            mov     r4, r0
    e6a0:       6800            ldr     r0, [r0, #0]
    e6a2:       b128            cbz     r0, e6b0 <_ZNSt6thread4joinEv+0x14>
    e6a4:       2100            movs    r1, #0
    e6a6:       f7fe fd19       bl      d0dc <pthread_join>
    e6aa:       b910            cbnz    r0, e6b2 <_ZNSt6thread4joinEv+0x16>
    e6ac:       6020            str     r0, [r4, #0]
    e6ae:       bd10            pop     {r4, pc}
    e6b0:       2016            movs    r0, #22
    e6b2:       f7f9 fcc5       bl      8040 <_ZSt20__throw_system_errori>
    e6b6:       bf00            nop
```

now, we can get the `pthread_join`, waiting end of the thread is normal.