### PR TITLE
Use int and unsigned int for int32_t and uint32_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ ExternalProject_add(gcc-base
     URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
     CONFIGURE_COMMAND ${compiler_flags} ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}
     # compile a native compiler so keep host == build
@@ -557,7 +557,7 @@ if(CMAKE_TOOLCHAIN_FILE)
         URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
         URL_HASH ${GCC_HASH}
         DOWNLOAD_DIR ${DOWNLOAD_DIR}
-        PATCH_COMMAND patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+        PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
         CONFIGURE_COMMAND ${compiler_flags} ${toolchain_tools}
         ${wrapper_command} <SOURCE_DIR>/configure
         --build=${build_native}
@@ -612,8 +612,7 @@ ExternalProject_add(gcc-final
     URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    PATCH_COMMAND
-        patch -d <SOURCE_DIR> -p3 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
     CONFIGURE_COMMAND ${compiler_flags} ${toolchain_tools} ${compiler_target_tools}
     ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}

--- a/patches/gcc/0001-gcc-8.patch
+++ b/patches/gcc/0001-gcc-8.patch
@@ -1,7 +1,8 @@
-diff -Nru a/src/gcc/gcc/config/arm/arm-c.c b/src/gcc/gcc/config/arm/arm-c.c
---- a/src/gcc/gcc/config/arm/arm-c.c	2018-02-09 13:23:46.000000000 +0100
-+++ b/src/gcc/gcc/config/arm/arm-c.c	2018-12-30 23:53:45.126193932 +0100
-@@ -229,6 +229,8 @@
+diff --git a/gcc/config/arm/arm-c.c b/gcc/config/arm/arm-c.c
+index 6e256ee0a..54e390c38 100644
+--- a/gcc/config/arm/arm-c.c
++++ b/gcc/config/arm/arm-c.c
+@@ -230,6 +230,8 @@ arm_cpu_cpp_builtins (struct cpp_reader * pfile)
    builtin_assert ("cpu=arm");
    builtin_assert ("machine=arm");
  
@@ -10,10 +11,29 @@ diff -Nru a/src/gcc/gcc/config/arm/arm-c.c b/src/gcc/gcc/config/arm/arm-c.c
    arm_cpu_builtins (pfile);
  }
  
-diff -Nru a/src/gcc/gcc/gcc.c b/src/gcc/gcc/gcc.c
---- a/src/gcc/gcc/gcc.c	2018-02-09 07:44:06.000000000 +0100
-+++ b/src/gcc/gcc/gcc.c	2018-12-30 23:54:38.202862228 +0100
-@@ -666,8 +666,9 @@
+diff --git a/gcc/config/arm/arm.h b/gcc/config/arm/arm.h
+index 9ee6a4eb5..1b6b4ba44 100644
+--- a/gcc/config/arm/arm.h
++++ b/gcc/config/arm/arm.h
+@@ -89,9 +89,10 @@ extern tree arm_fp16_type_node;
+ %{mbig-endian:%{mlittle-endian:						\
+ 	%e-mbig-endian and -mlittle-endian may not be used together}}"
+ 
+-#ifndef CC1_SPEC
+-#define CC1_SPEC ""
+-#endif
++#define CC1_SPEC                                                \
++  "%{!fshort-enums:%{!fno-short-enums:-fno-short-enums}} "      \
++  "%{!fshort-wchar:%{!fno-short-wchar:-fshort-wchar}} "
++#define CC1PLUS_SPEC CC1_SPEC
+ 
+ /* This macro defines names of additional specifications to put in the specs
+    that can be used in various specifications like CC1_SPEC.  Its definition
+diff --git a/gcc/gcc.c b/gcc/gcc.c
+index 4f57765b0..a4d5ffb14 100644
+--- a/gcc/gcc.c
++++ b/gcc/gcc.c
+@@ -674,8 +674,9 @@ proper position among the other output files.  */
  #endif
  
  /* config.h can define LIB_SPEC to override the default libraries.  */

--- a/patches/gcc/0001-gcc-8.patch
+++ b/patches/gcc/0001-gcc-8.patch
@@ -12,7 +12,7 @@ index 6e256ee0a..54e390c38 100644
  }
  
 diff --git a/gcc/config/arm/arm.h b/gcc/config/arm/arm.h
-index 9ee6a4eb5..1b6b4ba44 100644
+index 9ee6a4eb5..b89f85655 100644
 --- a/gcc/config/arm/arm.h
 +++ b/gcc/config/arm/arm.h
 @@ -89,9 +89,10 @@ extern tree arm_fp16_type_node;
@@ -29,6 +29,16 @@ index 9ee6a4eb5..1b6b4ba44 100644
  
  /* This macro defines names of additional specifications to put in the specs
     that can be used in various specifications like CC1_SPEC.  Its definition
+@@ -669,6 +670,9 @@ extern int arm_arch_cmse;
+ #define WCHAR_TYPE_SIZE BITS_PER_WORD
+ #endif
+ 
++/* use int and unsigned int for int32_t and uint32_t */
++#define STDINT_LONG32 0
++
+ /* Sized for fixed-point types.  */
+ 
+ #define SHORT_FRACT_TYPE_SIZE 8
 diff --git a/gcc/gcc.c b/gcc/gcc.c
 index 4f57765b0..a4d5ffb14 100644
 --- a/gcc/gcc.c

--- a/patches/gcc/0001-gcc-8.patch
+++ b/patches/gcc/0001-gcc-8.patch
@@ -15,20 +15,6 @@ diff --git a/gcc/config/arm/arm.h b/gcc/config/arm/arm.h
 index 9ee6a4eb5..b89f85655 100644
 --- a/gcc/config/arm/arm.h
 +++ b/gcc/config/arm/arm.h
-@@ -89,9 +89,10 @@ extern tree arm_fp16_type_node;
- %{mbig-endian:%{mlittle-endian:						\
- 	%e-mbig-endian and -mlittle-endian may not be used together}}"
- 
--#ifndef CC1_SPEC
--#define CC1_SPEC ""
--#endif
-+#define CC1_SPEC                                                \
-+  "%{!fshort-enums:%{!fno-short-enums:-fno-short-enums}} "      \
-+  "%{!fshort-wchar:%{!fno-short-wchar:-fshort-wchar}} "
-+#define CC1PLUS_SPEC CC1_SPEC
- 
- /* This macro defines names of additional specifications to put in the specs
-    that can be used in various specifications like CC1_SPEC.  Its definition
 @@ -669,6 +670,9 @@ extern int arm_arch_cmse;
  #define WCHAR_TYPE_SIZE BITS_PER_WORD
  #endif


### PR DESCRIPTION
- **About use int and unsigned int for int32_t and uint32_t**. This has been discussed a lot in the vitasdk and henkaku community but the focus was wrong. The change **is not about making long int size != int size** but to **make int the default datatype for 32 bits integers**. This patch is present in other platforms too.

Thanks @cuevavirus