### PR TITLE
signed chars by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,7 +462,7 @@ ExternalProject_add(gcc-base
     URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-10.patch
     CONFIGURE_COMMAND ${compiler_flags} ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}
     # compile a native compiler so keep host == build
@@ -554,7 +554,7 @@ if(CMAKE_TOOLCHAIN_FILE)
         URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
         URL_HASH ${GCC_HASH}
         DOWNLOAD_DIR ${DOWNLOAD_DIR}
-        PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+        PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-10.patch
         CONFIGURE_COMMAND ${compiler_flags} ${toolchain_tools}
         ${wrapper_command} <SOURCE_DIR>/configure
         --build=${build_native}
@@ -610,7 +610,7 @@ ExternalProject_add(gcc-final
     URL http://ftp.gnu.org/gnu/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.xz
     URL_HASH ${GCC_HASH}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-8.patch
+    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -t -N < ${PROJECT_SOURCE_DIR}/patches/gcc/0001-gcc-10.patch
     CONFIGURE_COMMAND ${compiler_flags} ${toolchain_tools} ${compiler_target_tools}
     ${wrapper_command} <SOURCE_DIR>/configure
     --build=${build_native}

--- a/patches/gcc/0001-gcc-10.patch
+++ b/patches/gcc/0001-gcc-10.patch
@@ -1,8 +1,8 @@
 diff --git a/gcc/config/arm/arm-c.c b/gcc/config/arm/arm-c.c
-index 6e256ee0a..54e390c38 100644
+index 7468a20bd..3496590c4 100644
 --- a/gcc/config/arm/arm-c.c
 +++ b/gcc/config/arm/arm-c.c
-@@ -230,6 +230,8 @@ arm_cpu_cpp_builtins (struct cpp_reader * pfile)
+@@ -372,6 +372,8 @@ arm_cpu_cpp_builtins (struct cpp_reader * pfile)
    builtin_assert ("cpu=arm");
    builtin_assert ("machine=arm");
  
@@ -12,10 +12,10 @@ index 6e256ee0a..54e390c38 100644
  }
  
 diff --git a/gcc/config/arm/arm.h b/gcc/config/arm/arm.h
-index 9ee6a4eb5..b89f85655 100644
+index 30e1d6dc9..bd5f7b19c 100644
 --- a/gcc/config/arm/arm.h
 +++ b/gcc/config/arm/arm.h
-@@ -669,6 +670,10 @@ extern int arm_arch_cmse;
+@@ -731,6 +731,10 @@ extern const int arm_arch_cde_coproc_bits[];
  #define WCHAR_TYPE_SIZE BITS_PER_WORD
  #endif
  
@@ -26,11 +26,34 @@ index 9ee6a4eb5..b89f85655 100644
  /* Sized for fixed-point types.  */
  
  #define SHORT_FRACT_TYPE_SIZE 8
+@@ -1996,7 +2000,7 @@ enum arm_auto_incmodes
+ /* signed 'char' is most compatible, but RISC OS wants it unsigned.
+    unsigned is probably best, but may break some code.  */
+ #ifndef DEFAULT_SIGNED_CHAR
+-#define DEFAULT_SIGNED_CHAR  0
++#define DEFAULT_SIGNED_CHAR  1
+ #endif
+ 
+ /* Max number of bytes we can move from memory to memory
+diff --git a/gcc/config/arm/arm.opt b/gcc/config/arm/arm.opt
+index cd3d8e1be..523b92aa1 100644
+--- a/gcc/config/arm/arm.opt
++++ b/gcc/config/arm/arm.opt
+@@ -30,6 +30,9 @@ const char *x_arm_cpu_string
+ TargetSave
+ const char *x_arm_tune_string
+ 
++pthread
++Driver
++
+ Enum
+ Name(tls_type) Type(enum arm_tls_type)
+ TLS dialect to use:
 diff --git a/gcc/gcc.c b/gcc/gcc.c
-index 4f57765b0..a4d5ffb14 100644
+index 9f790db0d..27a38bb02 100644
 --- a/gcc/gcc.c
 +++ b/gcc/gcc.c
-@@ -674,8 +674,9 @@ proper position among the other output files.  */
+@@ -673,8 +673,9 @@ proper position among the other output files.  */
  #endif
  
  /* config.h can define LIB_SPEC to override the default libraries.  */
@@ -41,25 +64,11 @@ index 4f57765b0..a4d5ffb14 100644
  #endif
  
  /* When using -fsplit-stack we need to wrap pthread_create, in order
-diff --git a/gcc/config/arm/arm.opt b/gcc/config/arm/arm.opt
-index af478a946b2..31d0ff7fd18 100644
---- a/gcc/config/arm/arm.opt
-+++ b/gcc/config/arm/arm.opt
-@@ -21,6 +21,9 @@
- HeaderInclude
- config/arm/arm-opts.h
- 
-+pthread
-+Driver
-+
- Enum
- Name(tls_type) Type(enum arm_tls_type)
- TLS dialect to use:
 diff --git a/libgomp/configure b/libgomp/configure
-index 6161da579c0..68c31eaad2b 100755
+index 5240f7e9d..de5dc96e4 100755
 --- a/libgomp/configure
 +++ b/libgomp/configure
-@@ -15720,29 +15720,6 @@ $as_echo "#define HAVE_UNAME 1" >>confdefs.h
+@@ -15768,29 +15768,6 @@ $as_echo "#define HAVE_UNAME 1" >>confdefs.h
  fi
  rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
  


### PR DESCRIPTION
* ~~Use -fvisibility=hidden by default (for https://github.com/vitasdk/vita-toolchain/pull/209)~~ we decided to let developers do that if they want to use automagic export generation.
* Use signed chars by default (arm has unsigned chars, but sce uses signed chars. this also improves compatibility with code written for x86)
* Adjust gcc patch offsets for gcc 10 and rename patch.