### PR TITLE
Removed windows mingw build from the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         name: vitasdk-linux
         path: build/*.tar.bz2
   build-macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,31 +53,4 @@ jobs:
       with:
         name: vitasdk-macos
         path: build/*.tar.bz2
-  build-windows:
-    runs-on: ubuntu-latest
-    container: ubuntu:14.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y software-properties-common
-        sudo add-apt-repository ppa:george-edison55/cmake-3.x
-        sudo apt-get update
-        sudo apt-get install -y cmake cmake-data git build-essential autoconf automake libtool texinfo bison flex pkg-config g++-mingw-w64 python
-    - name: Build
-      run: |
-        git config --global user.email "builds@travis-ci.com"
-        git config --global user.name "Travis CI"
-        unset CXX
-        unset CC
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_TOOLCHAIN_FILE=toolchain-x86_64-w64-mingw32.cmake
-        make -j$(nproc) tarball
-    - name: Upload artifacts
-      if: ${{ success() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: vitasdk-windows
-        path: build/*.tar.bz2
+


### PR DESCRIPTION
Removed windows mingw build from the pipeline for two reasons:
1. It wasn't building anyway, because [this](https://github.com/vitasdk/vita-toolchain/blob/a302403d560b9df6a34b57b454768f9a391e233d/src/elf-create-argp.c#L79) uses `strndup` which is only available on POSIX
2. At this point it makes more sense to use wsl2 on windows.

Also, updated macos runner due to actions/runner-images#5583