### PR TITLE
Revert "Removed windows mingw build from the pipeline"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,31 @@ jobs:
       with:
         name: vitasdk-macos
         path: build/*.tar.bz2
-
+  build-windows:
+    runs-on: ubuntu-latest
+    container: ubuntu:14.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository ppa:george-edison55/cmake-3.x
+        sudo apt-get update
+        sudo apt-get install -y cmake cmake-data git build-essential autoconf automake libtool texinfo bison flex pkg-config g++-mingw-w64 python
+    - name: Build
+      run: |
+        git config --global user.email "builds@travis-ci.com"
+        git config --global user.name "Travis CI"
+        unset CXX
+        unset CC
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_TOOLCHAIN_FILE=toolchain-x86_64-w64-mingw32.cmake
+        make -j$(nproc) tarball
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: vitasdk-windows
+        path: build/*.tar.bz2


### PR DESCRIPTION
This reverts commit dbfdc1f8c5fdc0cb102382231a3f35ba93211f4c.

`strndup` issue was resolved by vitasdk/vita-toolchain#230