### PR TITLE
Update minimum cmake to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 #
 
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(vitasdk)
 

--- a/patches/zlib.patch
+++ b/patches/zlib.patch
@@ -1,7 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b412dc7..a62204a 100644
+index b412dc7..7e847ee 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4.4)
++cmake_minimum_required(VERSION 3.16)
+ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
+ 
+ project(zlib C)
 @@ -189,25 +189,3 @@ endif()
  if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
      install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")


### PR DESCRIPTION
Make cmake version consistent and bump it to 3.16 (comes with ubuntu 20.04).
Compatibility with cmake < 3.5 was removed in cmake 4

Also requires https://github.com/vitasdk/libzip/pull/2