### PR TITLE
Match vdpm's pacman moving to libexec/vdpm

### DIFF
--- a/scripts/create-bootstrap-archive.sh
+++ b/scripts/create-bootstrap-archive.sh
@@ -27,7 +27,7 @@ case $host in
 			share/vdpm/refresh-repositories.ps1)
 		;;
 	*)
-		required+=(bin/vdpm bin/arm-vita-eabi-gcc bin/pacman bin/vdpm-channel \
+		required+=(bin/vdpm bin/arm-vita-eabi-gcc libexec/vdpm/pacman bin/vdpm-channel \
 			bin/include/refresh-repositories.sh)
 		;;
 esac

--- a/scripts/create-core-package.sh
+++ b/scripts/create-core-package.sh
@@ -38,8 +38,7 @@ else
 	client_paths=(
 		bin/vdpm
 		bin/vdpm-channel
-		bin/pacman
-		bin/pacman-conf
+		libexec/vdpm
 		bin/include
 		share/vdpm
 	)

--- a/scripts/install-vdpm-bundle.sh
+++ b/scripts/install-vdpm-bundle.sh
@@ -58,8 +58,8 @@ if [[ $host == *-w64-mingw32 ]]; then
 else
 	required+=(
 		bin/vdpm
-		bin/pacman
-		bin/pacman-conf
+		libexec/vdpm/pacman
+		libexec/vdpm/pacman-conf
 		bin/vdpm-channel
 		bin/include/refresh-repositories.sh
 	)

--- a/scripts/validate-core-package.sh
+++ b/scripts/validate-core-package.sh
@@ -106,7 +106,7 @@ if [[ $pkgname == vdpm ]]; then
 			}
 		done
 	else
-		for runtime_file in bin/vdpm bin/pacman bin/vdpm-channel; do
+		for runtime_file in bin/vdpm libexec/vdpm/pacman bin/vdpm-channel; do
 			grep -Fqx "$runtime_file" <<< "$archive_entries" || {
 				printf 'client package does not contain %s\n' "$runtime_file" >&2
 				exit 1

--- a/tests/package/test-bootstrap-archive.sh
+++ b/tests/package/test-bootstrap-archive.sh
@@ -8,10 +8,11 @@ cleanup() { rm -rf -- "$temporary_directory"; }
 trap cleanup EXIT
 
 sdk="$temporary_directory/sdk"
-mkdir -p "$sdk/bin/include" "$sdk/etc" "$sdk/share/vdpm/licenses"
-for file in vdpm arm-vita-eabi-gcc pacman vdpm-channel; do
+mkdir -p "$sdk/bin/include" "$sdk/libexec/vdpm" "$sdk/etc" "$sdk/share/vdpm/licenses"
+for file in vdpm arm-vita-eabi-gcc vdpm-channel; do
 	printf '%s\n' "$file" > "$sdk/bin/$file"
 done
+printf 'pacman\n' > "$sdk/libexec/vdpm/pacman"
 printf 'refresh\n' > "$sdk/bin/include/refresh-repositories.sh"
 printf '[options]\nArchitecture = x86_64-linux-gnu vita\n' > "$sdk/etc/pacman.conf"
 printf 'revision\n' > "$sdk/version_info.txt"
@@ -27,7 +28,7 @@ archive=vitasdk-bootstrap-x86_64-linux-gnu.tar.bz2
 cmp "$temporary_directory/one/$archive" "$temporary_directory/two/$archive"
 entries=$(tar -tjf "$temporary_directory/one/$archive")
 grep -qx 'vitasdk/bin/vdpm' <<< "$entries"
-grep -qx 'vitasdk/bin/pacman' <<< "$entries"
+grep -qx 'vitasdk/libexec/vdpm/pacman' <<< "$entries"
 grep -qx 'vitasdk/etc/pacman.conf' <<< "$entries"
 grep -qx 'vitasdk/version_info.txt' <<< "$entries"
 grep -qx 'vitasdk/share/vdpm/THIRD_PARTY_NOTICES.md' <<< "$entries"

--- a/tests/package/test-core-package.sh
+++ b/tests/package/test-core-package.sh
@@ -13,20 +13,26 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$sdk_root/bin/include" "$sdk_root/arm-vita-eabi/lib" \
+mkdir -p "$sdk_root/bin/include" "$sdk_root/libexec/vdpm" "$sdk_root/arm-vita-eabi/lib" \
 	"$sdk_root/share/vdpm/licenses" "$sdk_root/etc"
 cat > "$sdk_root/bin/arm-vita-eabi-gcc" <<'EOF'
 #!/usr/bin/env sh
 exit 0
 EOF
-for client in pacman pacman-conf vdpm vdpm-channel; do
+for client in vdpm vdpm-channel; do
 	cat > "$sdk_root/bin/$client" <<'EOF'
 #!/usr/bin/env sh
 exit 0
 EOF
 done
-chmod +x "$sdk_root/bin/arm-vita-eabi-gcc" "$sdk_root/bin/pacman" \
-	"$sdk_root/bin/pacman-conf" "$sdk_root/bin/vdpm" "$sdk_root/bin/vdpm-channel"
+for client in pacman pacman-conf; do
+	cat > "$sdk_root/libexec/vdpm/$client" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+done
+chmod +x "$sdk_root/bin/arm-vita-eabi-gcc" "$sdk_root/libexec/vdpm/pacman" \
+	"$sdk_root/libexec/vdpm/pacman-conf" "$sdk_root/bin/vdpm" "$sdk_root/bin/vdpm-channel"
 printf 'refresh\n' > "$sdk_root/bin/include/refresh-repositories.sh"
 printf 'archive\n' > "$sdk_root/arm-vita-eabi/lib/libfixture.a"
 printf 'source=fixture\n' > "$sdk_root/version_info.txt"
@@ -56,7 +62,7 @@ done
 core_entries=$(bsdtar -tf "$temporary_root/one/$core_name")
 client_entries=$(bsdtar -tf "$temporary_root/one/$client_name")
 
-for path in bin/vdpm bin/vdpm-channel bin/pacman bin/pacman-conf \
+for path in bin/vdpm bin/vdpm-channel libexec/vdpm/pacman libexec/vdpm/pacman-conf \
 		bin/include/refresh-repositories.sh share/vdpm/release-info.txt; do
 	grep -qx "$path" <<< "$client_entries" || {
 		printf 'the client package does not own %s\n' "$path" >&2

--- a/tests/package/test-vdpm-bundle.sh
+++ b/tests/package/test-vdpm-bundle.sh
@@ -55,9 +55,12 @@ fi
 
 unix_host=x86_64-linux-gnu
 unix_root="$temporary_directory/unix-input/vdpm-test-$unix_host"
-mkdir -p "$unix_root/bin/include" "$unix_root/share/vdpm/licenses"
-for relative_path in vdpm pacman pacman-conf vdpm-channel; do
+mkdir -p "$unix_root/bin/include" "$unix_root/libexec/vdpm" "$unix_root/share/vdpm/licenses"
+for relative_path in vdpm vdpm-channel; do
 	printf '%s\n' "$relative_path" > "$unix_root/bin/$relative_path"
+done
+for relative_path in pacman pacman-conf; do
+	printf '%s\n' "$relative_path" > "$unix_root/libexec/vdpm/$relative_path"
 done
 printf 'refresh\n' > "$unix_root/bin/include/refresh-repositories.sh"
 printf 'notices\n' > "$unix_root/share/vdpm/THIRD_PARTY_NOTICES.md"
@@ -78,7 +81,7 @@ unix_sdk="$temporary_directory/unix-sdk"
 "$repository_root/scripts/install-vdpm-bundle.sh" \
 	"$unix_bundle" "$unix_digest" "$unix_sdk" "$unix_host"
 test -f "$unix_sdk/bin/vdpm"
-test -f "$unix_sdk/bin/pacman"
+test -f "$unix_sdk/libexec/vdpm/pacman"
 test -f "$unix_sdk/bin/vdpm-channel"
 test -f "$unix_sdk/bin/include/refresh-repositories.sh"
 


### PR DESCRIPTION
# buildscripts — Match vdpm's pacman moving to libexec/vdpm

## What does this change?

Updates `scripts/create-core-package.sh`, `scripts/create-bootstrap-archive.sh`, `scripts/install-vdpm-bundle.sh`, `scripts/validate-core-package.sh`, and their tests to expect `pacman`/`pacman-conf` at `libexec/vdpm/` instead of `bin/`.

## Why is this change needed?

Companion to `vitasdk/vdpm`'s fix for vdpm#119, which moves `pacman` off `bin/` so it stops shadowing a Linux distribution's own pacman on `PATH`. This repo's packaging pipeline hardcoded the old path in five places to split the SDK stage directory into the `vitasdk-core` and `vdpm` packages, and to validate both.

## Testing

Ran `tests/package/test-core-package.sh` locally — full run, including installing both built packages into a real Arch Linux container and checking the dependency and file split — and `tests/package/test-bootstrap-archive.sh`. Both pass. Did not run `tests/package/test-vdpm-bundle.sh`'s Windows leg (needs a real stage-1 SDK this environment doesn't have); its Unix leg, which this change touches, ran and passed as part of that same script before the unrelated Windows step was reached.

## Compatibility

Depends on `VDPM_TAG` pointing at a vdpm release that carries the libexec move — it currently doesn't (pinned to v0.1.1, cut before that fix existed). Merging this before that release exists and the pin is bumped will break packaging with a missing-file error.

## Third-party material

None.

## AI assistance
- Claude Sonnet 5

## Additional context

Companion PR: `vitasdk/vdpm`#fix-pacman-path-collision (closes vdpm#119). Branched off `next-staged-build`, not `master` — this repo is still soaking on `next` per the release-candidate plan.
