### PR TITLE
ci: exercise BUILD_PACMAN_CLIENT=ON in its own job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,6 +360,8 @@ jobs:
           scripts/validate-core-package.sh "$pkg"
         done
     - name: Run the package test suite
+      env:
+        VITASDK_STAGE1_DIR: ${{ env.STAGE1_DIR }}
       run: |
         for test in tests/package/test-*.sh; do
           echo "== $test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,40 +316,17 @@ jobs:
   pacman-client-package:
     needs: stage1
     runs-on: ubuntu-24.04
-    # Runs inside the same glibc-2.31 base the published cores build in.
-    container: ubuntu:20.04
     env:
       CCACHE_MAXSIZE: 2G
       CCACHE_COMPRESS: "1"
       CCACHE_COMPRESSLEVEL: "6"
     steps:
-    - name: Install git for the checkout
-      # Without git in the container, checkout falls back to a tarball with no .git.
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: |
-        apt-get update
-        apt-get install -y git ca-certificates
-        # The mounted workspace belongs to the runner uid, not the container's root.
-        git config --global --add safe.directory '*'
     - uses: actions/checkout@v7
-    - name: Install dependencies
-      env:
-        DEBIAN_FRONTEND: noninteractive
+    - name: Install host dependencies
       run: |
-        # BUILD_PACMAN_CLIENT=ON builds vdpm's Pacman client with Meson;
-        # focal's cmake and meson predate what it needs, so pip supplies them.
-        apt-get install -y $DEBIAN_DEPS ninja-build libarchive-tools \
-          python3 python3-pip curl ca-certificates bzip2 xz-utils
-        pip3 install --quiet cmake==3.31.6 meson==1.11.0
-    - name: Enable ccache
-      run: |
-        if [ -x /usr/sbin/update-ccache-symlinks ]; then
-          /usr/sbin/update-ccache-symlinks
-        fi
-        ls /usr/lib/ccache
-        echo /usr/lib/ccache >> $GITHUB_PATH
-        echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+        sudo apt-get update
+        # The packaging tests drive docker and configure with meson on the host.
+        sudo apt-get install -y $DEBIAN_DEPS meson ninja-build libarchive-tools
     - name: ccache
       uses: actions/cache@v6
       with:
@@ -390,22 +367,19 @@ jobs:
         (cd vdpm-release && sha256sum -c ./*.sha256)
         echo "VDPM_BUNDLE=$PWD/vdpm-release/$archive" >> $GITHUB_ENV
         echo "VDPM_BUNDLE_SHA256=$(awk '{print $1}' vdpm-release/*.sha256)" >> $GITHUB_ENV
-    - name: Build with the package client enabled
+    - name: Build and contract-check inside ubuntu:20.04
+      # The published cores build on this glibc floor; the packaging tests need
+      # the runner's docker, so only the build enters the container.
       run: |
-        git config --global user.email "builds@ci.invalid"
-        git config --global user.name "CI"
-        # focal images carry no default locale and GCC's tarball needs one.
-        export LANG=C.UTF-8
-        mkdir -p build
-        cd build
-        cmake .. -DVITASDK_STAGE1_DIR="$STAGE1_DIR" \
-          -DBUILD_PACMAN_CLIENT=ON \
-          -DPACMAN_CLIENT_INSTALL_DIR="$PWD/vitasdk" \
-          -DVDPM_BUNDLE="$VDPM_BUNDLE" \
-          -DVDPM_BUNDLE_SHA256="$VDPM_BUNDLE_SHA256"
-        make -j$(getconf _NPROCESSORS_ONLN) tarball core-package bootstrap-archive
-    - name: Check the toolchain contract
-      run: make -C build check-toolchain-contract
+        mkdir -p "$HOME/.ccache"
+        docker run --rm -v "$PWD":"$PWD" -w "$PWD" \
+          -v "$HOME/.ccache":/root/.ccache \
+          -e CCACHE_DIR=/root/.ccache \
+          -e CCACHE_MAXSIZE -e CCACHE_COMPRESS -e CCACHE_COMPRESSLEVEL \
+          -e DEBIAN_DEPS -e STAGE1_DIR -e VDPM_BUNDLE -e VDPM_BUNDLE_SHA256 \
+          -e VITASDK_SOURCE_REVISION='${{ github.event.pull_request.head.sha || github.sha }}' \
+          -e VITASDK_SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)" \
+          ubuntu:20.04 "$PWD/scripts/build-core-in-container.sh"
     - name: Validate the core package
       run: |
         for pkg in build/packages/*.pkg.tar.xz; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,24 +41,33 @@ jobs:
   # ---------------------------------------------------------------------
   stage1:
     runs-on: ubuntu-24.04
+    # The Linux SDK legs build inside the glibc-2.31 base the published cores use.
+    container: ubuntu:20.04
     env:
       CCACHE_MAXSIZE: 2G
       CCACHE_COMPRESS: "1"
       CCACHE_COMPRESSLEVEL: "6"
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-    - name: Install dependencies
+    - name: Install git for the checkout
+      # Without git in the container, checkout falls back to a tarball with no .git.
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update
-        sudo apt-get install -y $DEBIAN_DEPS
+        apt-get update
+        apt-get install -y git ca-certificates
+    - uses: actions/checkout@v7
+    - name: Install dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get install -y $DEBIAN_DEPS python3 curl bzip2 xz-utils
     - name: Enable ccache
       run: |
         # gcc, binutils, gdb and newlib are autotools: they honour no CMake
         # variable, and a shim directory in PATH is the only way they pick
         # ccache up. Listing it leaves the covered compilers in the log.
         if [ -x /usr/sbin/update-ccache-symlinks ]; then
-          sudo /usr/sbin/update-ccache-symlinks
+          /usr/sbin/update-ccache-symlinks
         fi
         ls /usr/lib/ccache
         echo /usr/lib/ccache >> $GITHUB_PATH
@@ -115,28 +124,39 @@ jobs:
         include:
           - runner: ubuntu-24.04
             name: linux-x86_64
+            container: ubuntu:20.04
             ccache_dir: ~/.ccache
           - runner: ubuntu-24.04-arm
             name: linux-arm64
+            container: ubuntu:20.04
             ccache_dir: ~/.ccache
           - runner: macos-14
             name: macos-arm64
             ccache_dir: ~/Library/Caches/ccache
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     env:
       CCACHE_MAXSIZE: 2G
       CCACHE_COMPRESS: "1"
       CCACHE_COMPRESSLEVEL: "6"
     steps:
+    - name: Install git for the checkout
+      if: runner.os == 'Linux'
+      # Without git in the container, checkout falls back to a tarball with no .git.
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get update
+        apt-get install -y git ca-certificates
     - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
     - name: Install dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
         if [ "$RUNNER_OS" = "macOS" ]; then
           brew install autoconf automake libtool texinfo ccache
         else
-          sudo apt-get update
-          sudo apt-get install -y $DEBIAN_DEPS
+          apt-get install -y $DEBIAN_DEPS python3 curl bzip2 xz-utils
         fi
     - name: Enable ccache
       run: |
@@ -145,7 +165,7 @@ jobs:
           echo "CCACHE_DIR=$HOME/Library/Caches/ccache" >> $GITHUB_ENV
         else
           if [ -x /usr/sbin/update-ccache-symlinks ]; then
-            sudo /usr/sbin/update-ccache-symlinks
+            /usr/sbin/update-ccache-symlinks
           fi
           shims=/usr/lib/ccache
           echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
@@ -295,12 +315,18 @@ jobs:
       CCACHE_COMPRESS: "1"
       CCACHE_COMPRESSLEVEL: "6"
     steps:
+    - name: Install git for the checkout
+      # Without git in the container, checkout falls back to a tarball with no .git.
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get update
+        apt-get install -y git ca-certificates
     - uses: actions/checkout@v7
     - name: Install dependencies
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        apt-get update
         # BUILD_PACMAN_CLIENT=ON builds vdpm's Pacman client with Meson;
         # focal's cmake and meson predate what it needs, so pip supplies them.
         apt-get install -y $DEBIAN_DEPS ninja-build libarchive-tools \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,12 @@ on:
   repository_dispatch:
     types: [run_build]
 
+# A push to a branch with an open pull request fires both triggers; one
+# group per head commit keeps a single run of the pair alive.
+concurrency:
+  group: build-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
 env:
   DEBIAN_DEPS: cmake cmake-data git build-essential autoconf automake libtool texinfo bison flex pkg-config ccache
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,6 +275,110 @@ jobs:
         name: vitasdk-${{ matrix.name }}
         path: build/*.tar.bz2
 
+  pacman-client-package:
+    needs: stage1
+    runs-on: ubuntu-24.04
+    env:
+      CCACHE_MAXSIZE: 2G
+      CCACHE_COMPRESS: "1"
+      CCACHE_COMPRESSLEVEL: "6"
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        # BUILD_PACMAN_CLIENT=ON builds vdpm's Pacman client with Meson.
+        sudo apt-get install -y $DEBIAN_DEPS meson ninja-build libarchive-tools
+    - name: Enable ccache
+      run: |
+        if [ -x /usr/sbin/update-ccache-symlinks ]; then
+          sudo /usr/sbin/update-ccache-symlinks
+        fi
+        ls /usr/lib/ccache
+        echo /usr/lib/ccache >> $GITHUB_PATH
+        echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+    - name: ccache
+      uses: actions/cache@v6
+      with:
+        path: ~/.ccache
+        key: pacman-client-ccache-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          pacman-client-ccache-${{ github.ref }}-
+          pacman-client-ccache-
+    - name: downloads
+      uses: actions/cache@v6
+      with:
+        path: build/downloads
+        key: linux-x86_64-pacman-client-downloads-${{ hashFiles('CMakeLists.txt', 'cmake/Components.cmake') }}
+        restore-keys: |
+          linux-x86_64-pacman-client-downloads-
+    - name: Fetch the stage-1 sysroot
+      uses: actions/download-artifact@v7
+      with:
+        name: vitasdk-sysroot
+        path: stage1-artifact
+    - name: Unpack the stage-1 sysroot
+      run: |
+        mkdir -p stage1
+        tar -xjf stage1-artifact/*.tar.bz2 -C stage1
+        STAGE1_DIR=$(dirname "$(dirname "$(dirname "$(find "$PWD/stage1" -type f -path '*/arm-vita-eabi/lib/libc.a' | head -1)")")")
+        test -n "$STAGE1_DIR"
+        echo "STAGE1_DIR=$STAGE1_DIR" >> $GITHUB_ENV
+    - name: Download the vdpm host bundle
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # The packaging scripts read metadata the bundle installs, so the
+        # published configuration needs the real bundle, like autobuilds.
+        tag=$(sed -n 's/^set(VDPM_TAG \([^ ]*\) .*/\1/p' cmake/Components.cmake)
+        mkdir vdpm-release
+        gh release download "$tag" --repo vitasdk/vdpm \
+          --pattern "vdpm-*-x86_64-linux-gnu.tar.bz2" \
+          --pattern "vdpm-*-x86_64-linux-gnu.tar.bz2.sha256" \
+          --dir vdpm-release
+        (cd vdpm-release && sha256sum -c ./*.sha256)
+        echo "VDPM_BUNDLE=$PWD/$(ls vdpm-release/*.tar.bz2)" >> $GITHUB_ENV
+        echo "VDPM_BUNDLE_SHA256=$(awk '{print $1}' vdpm-release/*.sha256)" >> $GITHUB_ENV
+    - name: Build with the package client enabled
+      run: |
+        git config --global user.email "builds@ci.invalid"
+        git config --global user.name "CI"
+        mkdir -p build
+        cd build
+        cmake .. -DVITASDK_STAGE1_DIR="$STAGE1_DIR" \
+          -DBUILD_PACMAN_CLIENT=ON \
+          -DPACMAN_CLIENT_INSTALL_DIR="$PWD/vitasdk" \
+          -DVDPM_BUNDLE="$VDPM_BUNDLE" \
+          -DVDPM_BUNDLE_SHA256="$VDPM_BUNDLE_SHA256"
+        make -j$(getconf _NPROCESSORS_ONLN) tarball core-package bootstrap-archive
+    - name: Check the toolchain contract
+      run: make -C build check-toolchain-contract
+    - name: Validate the core package
+      run: |
+        for pkg in build/packages/*.pkg.tar.xz; do
+          scripts/validate-core-package.sh "$pkg"
+        done
+    - name: Run the package test suite
+      run: |
+        for test in tests/package/test-*.sh; do
+          echo "== $test"
+          "$test"
+        done
+    - name: ccache statistics
+      if: ${{ always() }}
+      run: ccache --show-stats
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v7
+      with:
+        # Distinct from stage2's vitasdk-linux-x86_64: stage3 downloads that.
+        name: vitasdk-linux-x86_64-pacman-client
+        path: |
+          build/*.tar.bz2
+          build/packages/*.pkg.tar.xz
+          build/bootstraps/*
+
   # ---------------------------------------------------------------------
   # Stage 3: the canadian crosses. Their gcc is built for a host that
   # cannot run on the machine building it, and all-gcc runs the compiler

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
       run: |
         git config --global user.email "builds@ci.invalid"
         git config --global user.name "CI"
+        # focal images carry no default locale and GCC's tarball needs one.
+        export LANG=C.UTF-8
         mkdir -p build
         cd build
         cmake .. -DVITASDK_TARGET_ONLY=ON
@@ -181,6 +183,8 @@ jobs:
       run: |
         git config --global user.email "builds@ci.invalid"
         git config --global user.name "CI"
+        # focal images carry no default locale and GCC's tarball needs one.
+        export LANG=C.UTF-8
         mkdir -p build
         cd build
         cmake .. -DVITASDK_STAGE1_DIR="$STAGE1_DIR"
@@ -284,22 +288,28 @@ jobs:
   pacman-client-package:
     needs: stage1
     runs-on: ubuntu-24.04
+    # Runs inside the same glibc-2.31 base the published cores build in.
+    container: ubuntu:20.04
     env:
       CCACHE_MAXSIZE: 2G
       CCACHE_COMPRESS: "1"
       CCACHE_COMPRESSLEVEL: "6"
     steps:
     - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
     - name: Install dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get update
-        # BUILD_PACMAN_CLIENT=ON builds vdpm's Pacman client with Meson.
-        sudo apt-get install -y $DEBIAN_DEPS meson ninja-build libarchive-tools
+        apt-get update
+        # BUILD_PACMAN_CLIENT=ON builds vdpm's Pacman client with Meson;
+        # focal's cmake and meson predate what it needs, so pip supplies them.
+        apt-get install -y $DEBIAN_DEPS ninja-build libarchive-tools \
+          python3 python3-pip curl ca-certificates bzip2 xz-utils
+        pip3 install --quiet cmake==3.31.6 meson==1.11.0
     - name: Enable ccache
       run: |
         if [ -x /usr/sbin/update-ccache-symlinks ]; then
-          sudo /usr/sbin/update-ccache-symlinks
+          /usr/sbin/update-ccache-symlinks
         fi
         ls /usr/lib/ccache
         echo /usr/lib/ccache >> $GITHUB_PATH
@@ -332,24 +342,24 @@ jobs:
         test -n "$STAGE1_DIR"
         echo "STAGE1_DIR=$STAGE1_DIR" >> $GITHUB_ENV
     - name: Download the vdpm host bundle
-      env:
-        GH_TOKEN: ${{ github.token }}
       run: |
         # The packaging scripts read metadata the bundle installs, so the
         # published configuration needs the real bundle, like autobuilds.
         tag=$(sed -n 's/^set(VDPM_TAG \([^ ]*\) .*/\1/p' cmake/Components.cmake)
+        archive="vdpm-${tag#v}-x86_64-linux-gnu.tar.bz2"
+        base="https://github.com/vitasdk/vdpm/releases/download/$tag"
         mkdir vdpm-release
-        gh release download "$tag" --repo vitasdk/vdpm \
-          --pattern "vdpm-*-x86_64-linux-gnu.tar.bz2" \
-          --pattern "vdpm-*-x86_64-linux-gnu.tar.bz2.sha256" \
-          --dir vdpm-release
+        curl -fsSL --retry 3 -o "vdpm-release/$archive" "$base/$archive"
+        curl -fsSL --retry 3 -o "vdpm-release/$archive.sha256" "$base/$archive.sha256"
         (cd vdpm-release && sha256sum -c ./*.sha256)
-        echo "VDPM_BUNDLE=$PWD/$(ls vdpm-release/*.tar.bz2)" >> $GITHUB_ENV
+        echo "VDPM_BUNDLE=$PWD/vdpm-release/$archive" >> $GITHUB_ENV
         echo "VDPM_BUNDLE_SHA256=$(awk '{print $1}' vdpm-release/*.sha256)" >> $GITHUB_ENV
     - name: Build with the package client enabled
       run: |
         git config --global user.email "builds@ci.invalid"
         git config --global user.name "CI"
+        # focal images carry no default locale and GCC's tarball needs one.
+        export LANG=C.UTF-8
         mkdir -p build
         cd build
         cmake .. -DVITASDK_STAGE1_DIR="$STAGE1_DIR" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y git ca-certificates
+        # The mounted workspace belongs to the runner uid, not the container's root.
+        git config --global --add safe.directory '*'
     - uses: actions/checkout@v7
     - name: Install dependencies
       env:
@@ -150,6 +152,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y git ca-certificates
+        # The mounted workspace belongs to the runner uid, not the container's root.
+        git config --global --add safe.directory '*'
     - uses: actions/checkout@v7
     - name: Install dependencies
       env:
@@ -326,6 +330,8 @@ jobs:
       run: |
         apt-get update
         apt-get install -y git ca-certificates
+        # The mounted workspace belongs to the runner uid, not the container's root.
+        git config --global --add safe.directory '*'
     - uses: actions/checkout@v7
     - name: Install dependencies
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,9 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        apt-get install -y $DEBIAN_DEPS python3 curl bzip2 xz-utils
+        apt-get install -y $DEBIAN_DEPS python3 python3-pip curl bzip2 xz-utils
+        # focal's cmake is 3.16 and the build needs 3.19 features.
+        pip3 install --quiet cmake==3.31.6
     - name: Enable ccache
       run: |
         # gcc, binutils, gdb and newlib are autotools: they honour no CMake
@@ -156,7 +158,9 @@ jobs:
         if [ "$RUNNER_OS" = "macOS" ]; then
           brew install autoconf automake libtool texinfo ccache
         else
-          apt-get install -y $DEBIAN_DEPS python3 curl bzip2 xz-utils
+          apt-get install -y $DEBIAN_DEPS python3 python3-pip curl bzip2 xz-utils
+          # focal's cmake is 3.16 and the build needs 3.19 features.
+          pip3 install --quiet cmake==3.31.6
         fi
     - name: Enable ccache
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 #
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.19)
 
 project(vitasdk)
 

--- a/scripts/build-core-in-container.sh
+++ b/scripts/build-core-in-container.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Provisions a stock ubuntu:20.04, then builds and contract-checks the core there.
+set -eux
+export DEBIAN_FRONTEND=noninteractive
+export LANG=C.UTF-8
+apt-get update -qq
+# shellcheck disable=SC2086
+apt-get install -y -qq $DEBIAN_DEPS ninja-build libarchive-tools \
+    python3 python3-pip curl ca-certificates bzip2 xz-utils
+# focal's cmake and meson predate what the package client needs.
+pip3 install --quiet cmake==3.31.6 meson==1.11.0
+if [ -x /usr/sbin/update-ccache-symlinks ]; then
+    /usr/sbin/update-ccache-symlinks
+fi
+export PATH=/usr/lib/ccache:$PATH
+git config --global user.email "builds@ci.invalid"
+git config --global user.name "CI"
+git config --global --add safe.directory '*'
+mkdir -p build
+cd build
+cmake .. -DVITASDK_STAGE1_DIR="$STAGE1_DIR" \
+    -DBUILD_PACMAN_CLIENT=ON \
+    -DPACMAN_CLIENT_INSTALL_DIR="$PWD/vitasdk" \
+    -DVITASDK_SOURCE_REVISION="$VITASDK_SOURCE_REVISION" \
+    -DVITASDK_SOURCE_DATE_EPOCH="$VITASDK_SOURCE_DATE_EPOCH" \
+    -DVDPM_BUNDLE="$VDPM_BUNDLE" \
+    -DVDPM_BUNDLE_SHA256="$VDPM_BUNDLE_SHA256"
+make -j"$(nproc)" tarball core-package bootstrap-archive
+make check-toolchain-contract

--- a/tests/package/test-vdpm-bundle.sh
+++ b/tests/package/test-vdpm-bundle.sh
@@ -94,22 +94,29 @@ set(CMAKE_CXX_COMPILER /usr/bin/c++)
 set(CMAKE_C_COMPILER_FORCED TRUE)
 set(CMAKE_CXX_COMPILER_FORCED TRUE)
 set(CMAKE_RC_COMPILER /usr/bin/true)
+set(CMAKE_EXE_LINKER_FLAGS "-static")
 EOF
 configure="$temporary_directory/configure"
+# The staged build refuses a toolchain configure without a stage-1 SDK.
+stage1_args=()
+if [[ -n ${VITASDK_STAGE1_DIR:-} ]]; then
+	stage1_args=(-DVITASDK_STAGE1_DIR="$VITASDK_STAGE1_DIR")
+fi
 cmake -S "$repository_root" -B "$configure" \
 	-DCMAKE_TOOLCHAIN_FILE="$toolchain" \
+	"${stage1_args[@]}" \
 	-DBUILD_PACMAN_CLIENT=ON \
 	-DVDPM_BUNDLE="$bundle" \
 	-DVDPM_BUNDLE_SHA256="$digest" >/dev/null
-build_zlib_config="$configure/zlib_build-prefix/tmp/zlib_build-cfgcmd.txt"
 host_zlib_config="$configure/zlib_host-prefix/tmp/zlib_host-cfgcmd.txt"
-test -f "$build_zlib_config"
 test -f "$host_zlib_config"
-if grep -Fq -- '-DCMAKE_EXE_LINKER_FLAGS=-static ' "$build_zlib_config"; then
-	printf 'Windows target linker flags leaked into build-machine dependencies\n' >&2
+# A staged cross configure imports every build-machine artifact, so no
+# *_build project may exist for target flags to leak into.
+if compgen -G "$configure/*_build-prefix" >/dev/null; then
+	printf 'build-machine dependency projects reappeared in a staged cross configure\n' >&2
 	exit 1
 fi
-grep -Fq -- '-DCMAKE_EXE_LINKER_FLAGS=-static ' "$host_zlib_config"
+grep -Fq -- '-DCMAKE_EXE_LINKER_FLAGS=-static' "$host_zlib_config"
 cmake --build "$configure" --target vdpm >/dev/null
 test -f "$configure/vitasdk/bin/vdpm.exe"
 test -f "$configure/vitasdk/share/vdpm/msys/usr/bin/pacman.exe"


### PR DESCRIPTION
autobuilds always publishes with `BUILD_PACMAN_CLIENT=ON`, but no job in this repository ever built that configuration, which is how #151 could merge green while its own commit message admitted the packaging would fail until the vdpm tag moved. This adds a linux-x86_64 job that turns it on, reuses stage 1's sysroot, and runs `create-core-package.sh`, `create-bootstrap-archive.sh`, `validate-core-package.sh` and the `tests/package/test-*.sh` suite against the result — with the tag now at v0.1.2, it exercises the libexec layout end to end.

Kept out of the stage-2 matrix so its extra dependencies (Meson, a Pacman built from source) never touch the ten hosts already green there.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).
