### PR TITLE
Add the verify CLI for grouped release trees

### DIFF
--- a/buildscripts-ci
+++ b/buildscripts-ci
@@ -5,6 +5,7 @@ set -euo pipefail
 usage() {
 	printf 'usage: %s <command> [args...]\n' "$0" >&2
 	printf '       %s describe --profile <name> [--revision <rev>] [--previous-version <v>] [--output <path>]\n' "$0" >&2
+	printf '       %s verify --tree <dir>\n' "$0" >&2
 	exit 2
 }
 
@@ -17,6 +18,9 @@ shift
 case $command in
 	describe)
 		exec python3 "$script_directory/scripts/describe.py" "$@"
+		;;
+	verify)
+		exec python3 "$script_directory/scripts/verify-release-tree.py" "$@"
 		;;
 	*)
 		printf 'unknown buildscripts-ci command: %s\n' "$command" >&2

--- a/scripts/verify-release-tree.py
+++ b/scripts/verify-release-tree.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Black-box validator for a grouped VitaSDK release tree (buildscripts-ci verify)."""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+
+SUPPORTED_SCHEMA = 1
+MANIFEST_NAME = "release.json"
+CHECKSUM_NAME = "SHA256SUMS"
+
+
+class VerificationError(Exception):
+    pass
+
+
+def fail(message):
+    raise VerificationError(message)
+
+
+def require_string(value, field):
+    if not isinstance(value, str) or not value:
+        fail(f"{field} must be a non-empty string")
+    return value
+
+
+def require_revision(value, field):
+    value = require_string(value, field)
+    if len(value) != 40 or any(c not in "0123456789abcdef" for c in value.lower()):
+        fail(f"{field} is not a 40-character git revision: {value!r}")
+    return value
+
+
+def safe_relative_path(value, context):
+    value = require_string(value, context)
+    parts = value.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        fail(f"{context} is not a safe relative path: {value!r}")
+    return value
+
+
+def load_manifest(tree):
+    manifest_path = os.path.join(tree, MANIFEST_NAME)
+    if not os.path.isfile(manifest_path):
+        fail(f"missing release manifest: {MANIFEST_NAME}")
+    with open(manifest_path, encoding="utf-8") as handle:
+        try:
+            manifest = json.load(handle)
+        except json.JSONDecodeError as exc:
+            fail(f"{MANIFEST_NAME} is not valid JSON: {exc}")
+    if not isinstance(manifest, dict):
+        fail(f"{MANIFEST_NAME} does not contain a JSON object")
+    return manifest
+
+
+def validate_manifest(manifest):
+    schema = manifest.get("schema")
+    if schema != SUPPORTED_SCHEMA:
+        fail(
+            f"unsupported release manifest schema: tree declares {schema!r}, "
+            f"this verify supports {SUPPORTED_SCHEMA}"
+        )
+
+    build_id = require_string(manifest.get("build_id"), "build_id")
+    require_revision(manifest.get("buildscripts_revision"), "buildscripts_revision")
+    require_string(manifest.get("profile"), "profile")
+
+    hosts = manifest.get("hosts")
+    if not isinstance(hosts, list) or not hosts:
+        fail("hosts must be a non-empty list")
+
+    declared_files = {MANIFEST_NAME, CHECKSUM_NAME}
+    seen_hosts = set()
+    for entry in hosts:
+        if not isinstance(entry, dict):
+            fail("each hosts[] entry must be an object")
+        name = require_string(entry.get("name"), "hosts[].name")
+        if name in seen_hosts:
+            fail(f"duplicate host in manifest: {name}")
+        seen_hosts.add(name)
+
+        host_build_id = require_string(entry.get("build_id"), f"hosts[{name}].build_id")
+        if host_build_id != build_id:
+            fail(
+                f"host {name} echoes build_id {host_build_id!r}, "
+                f"the manifest declares {build_id!r}"
+            )
+
+        artifacts = entry.get("artifacts")
+        if not isinstance(artifacts, list) or not artifacts:
+            fail(f"hosts[{name}].artifacts must be a non-empty list")
+        for artifact in artifacts:
+            declared_files.add(safe_relative_path(artifact, f"hosts[{name}].artifacts[]"))
+
+    return build_id, len(hosts), declared_files
+
+
+def list_tree_files(tree):
+    # the distribution contract is a flat tree: no subdirectories anywhere
+    files = set()
+    for entry in os.listdir(tree):
+        path = os.path.join(tree, entry)
+        if os.path.islink(path) or not os.path.isfile(path):
+            fail(f"grouped release tree contains a non-regular entry: {entry}")
+        files.add(entry)
+    return files
+
+
+def parse_checksum_file(path):
+    recorded = {}
+    with open(path, encoding="utf-8") as handle:
+        for lineno, raw_line in enumerate(handle, 1):
+            line = raw_line.rstrip("\r\n")
+            if not line:
+                continue
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                fail(f"{CHECKSUM_NAME}:{lineno}: malformed line: {line!r}")
+            digest, filename = parts
+            if filename.startswith("*"):
+                filename = filename[1:]
+            if filename in recorded:
+                fail(f"{CHECKSUM_NAME} lists {filename} more than once")
+            recorded[filename] = digest.lower()
+    return recorded
+
+
+def sha256_of(path):
+    hasher = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def verify_checksums(tree, expected_hashed):
+    checksum_path = os.path.join(tree, CHECKSUM_NAME)
+    recorded = parse_checksum_file(checksum_path)
+
+    recorded_files = set(recorded)
+    if recorded_files != expected_hashed:
+        details = []
+        missing = sorted(expected_hashed - recorded_files)
+        extra = sorted(recorded_files - expected_hashed)
+        if missing:
+            details.append(f"missing from {CHECKSUM_NAME}: {', '.join(missing)}")
+        if extra:
+            details.append(f"unexpected in {CHECKSUM_NAME}: {', '.join(extra)}")
+        fail("; ".join(details))
+
+    for filename in sorted(recorded):
+        actual = sha256_of(os.path.join(tree, filename))
+        expected = recorded[filename]
+        if actual != expected:
+            fail(f"checksum mismatch for {filename}: expected {expected}, got {actual}")
+
+
+def verify_tree(tree):
+    if not os.path.isdir(tree):
+        fail(f"release tree not found: {tree}")
+
+    manifest = load_manifest(tree)
+    build_id, host_count, declared_files = validate_manifest(manifest)
+
+    actual_files = list_tree_files(tree)
+    missing = sorted(declared_files - actual_files)
+    extra = sorted(actual_files - declared_files)
+    if missing or extra:
+        details = []
+        if missing:
+            details.append(f"missing declared artifacts: {', '.join(missing)}")
+        if extra:
+            details.append(f"undeclared files present: {', '.join(extra)}")
+        fail("; ".join(details))
+
+    expected_hashed = declared_files - {CHECKSUM_NAME}
+    verify_checksums(tree, expected_hashed)
+
+    artifact_count = len(declared_files) - 2  # exclude the manifest and SHA256SUMS
+    print(
+        f"verified release tree: build_id={build_id} "
+        f"hosts={host_count} artifacts={artifact_count}"
+    )
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(prog="buildscripts-ci verify")
+    parser.add_argument("--tree", required=True, help="grouped release tree to validate")
+    args = parser.parse_args(argv)
+
+    try:
+        verify_tree(os.path.realpath(args.tree))
+    except VerificationError as exc:
+        print(f"verify: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/protocol/test-verify.sh
+++ b/tests/protocol/test-verify.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+cli="$repository_root/buildscripts-ci"
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/buildscripts-verify.XXXXXXXX")
+cleanup() { rm -rf -- "$temporary_root"; }
+trap cleanup EXIT
+
+sha256_of() {
+	if command -v sha256sum >/dev/null; then
+		sha256sum "$1" | awk '{print $1}'
+	else
+		shasum -a 256 "$1" | awk '{print $1}'
+	fi
+}
+
+# verify never opens packages, so synthetic placeholder files are enough.
+build_valid_tree() {
+	local tree=$1
+	mkdir -p "$tree"
+	printf 'core\n' > "$tree/vitasdk-core-0.1-1-x86_64-linux-gnu.pkg.tar.xz"
+	printf 'client\n' > "$tree/vdpm-0.1.0-1-x86_64-linux-gnu.pkg.tar.xz"
+	printf 'db\n' > "$tree/x86_64-linux-gnu.db"
+	printf 'files\n' > "$tree/x86_64-linux-gnu.files"
+	printf 'bootstrap\n' > "$tree/vitasdk-bootstrap-x86_64-linux-gnu.tar.bz2"
+	printf 'core\n' > "$tree/vitasdk-core-0.1-1-x86_64-w64-mingw32.pkg.tar.xz"
+	printf 'client\n' > "$tree/vdpm-0.1.0-1-x86_64-w64-mingw32.pkg.tar.xz"
+	printf 'db\n' > "$tree/x86_64-w64-mingw32.db"
+	printf 'files\n' > "$tree/x86_64-w64-mingw32.files"
+	printf 'bootstrap\n' > "$tree/vitasdk-bootstrap-x86_64-w64-mingw32.tar.bz2"
+
+	cat > "$tree/release.json" <<'EOF'
+{
+  "schema": 1,
+  "build_id": "sha256:test-build-id",
+  "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567",
+  "profile": "vita",
+  "hosts": [
+    {
+      "name": "x86_64-linux-gnu",
+      "build_id": "sha256:test-build-id",
+      "artifacts": [
+        "vitasdk-core-0.1-1-x86_64-linux-gnu.pkg.tar.xz",
+        "vdpm-0.1.0-1-x86_64-linux-gnu.pkg.tar.xz",
+        "x86_64-linux-gnu.db",
+        "x86_64-linux-gnu.files",
+        "vitasdk-bootstrap-x86_64-linux-gnu.tar.bz2"
+      ]
+    },
+    {
+      "name": "x86_64-w64-mingw32",
+      "build_id": "sha256:test-build-id",
+      "artifacts": [
+        "vitasdk-core-0.1-1-x86_64-w64-mingw32.pkg.tar.xz",
+        "vdpm-0.1.0-1-x86_64-w64-mingw32.pkg.tar.xz",
+        "x86_64-w64-mingw32.db",
+        "x86_64-w64-mingw32.files",
+        "vitasdk-bootstrap-x86_64-w64-mingw32.tar.bz2"
+      ]
+    }
+  ]
+}
+EOF
+
+	: > "$tree/SHA256SUMS"
+	(
+		cd "$tree"
+		for asset in *; do
+			[[ $asset == SHA256SUMS ]] && continue
+			printf '%s  %s\n' "$(sha256_of "$asset")" "$asset" >> SHA256SUMS
+		done
+	)
+}
+
+# $2 is a Python statement applied to release.json's parsed data (as `data`).
+edit_manifest() {
+	local tree=$1 expression=$2
+	python3 - "$tree/release.json" "$expression" <<'PYEOF'
+import json
+import sys
+
+path, expression = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+	data = json.load(handle)
+exec(expression)
+with open(path, "w", encoding="utf-8") as handle:
+	json.dump(data, handle, indent=2)
+PYEOF
+}
+
+assert_fails() {
+	local description=$1 tree=$2 expected_substring=$3
+	local output status
+	output=$("$cli" verify --tree "$tree" 2>&1) && status=0 || status=$?
+	if [[ $status -eq 0 ]]; then
+		printf 'expected failure (%s), verify exited 0\n' "$description" >&2
+		exit 1
+	fi
+	if [[ $output != *"$expected_substring"* ]]; then
+		printf 'expected failure (%s) to mention %q, got: %s\n' \
+			"$description" "$expected_substring" "$output" >&2
+		exit 1
+	fi
+}
+
+valid_tree="$temporary_root/valid"
+build_valid_tree "$valid_tree"
+output=$("$cli" verify --tree "$valid_tree")
+[[ $output == *"hosts=2"* && $output == *"artifacts=10"* ]] || {
+	printf 'unexpected success output: %s\n' "$output" >&2
+	exit 1
+}
+
+assert_fails "nonexistent tree" "$temporary_root/does-not-exist" "not found"
+
+no_manifest="$temporary_root/no-manifest"
+build_valid_tree "$no_manifest"
+rm -f "$no_manifest/release.json"
+assert_fails "missing manifest" "$no_manifest" "missing release manifest"
+
+bad_json="$temporary_root/bad-json"
+build_valid_tree "$bad_json"
+printf 'not json' > "$bad_json/release.json"
+assert_fails "malformed manifest" "$bad_json" "not valid JSON"
+
+bad_schema="$temporary_root/bad-schema"
+build_valid_tree "$bad_schema"
+edit_manifest "$bad_schema" 'data["schema"] = 2'
+assert_fails "unsupported schema" "$bad_schema" "tree declares 2, this verify supports 1"
+
+mismatched_build_id="$temporary_root/mismatched-build-id"
+build_valid_tree "$mismatched_build_id"
+edit_manifest "$mismatched_build_id" 'data["hosts"][0]["build_id"] = "sha256:other"'
+assert_fails "build_id mismatch" "$mismatched_build_id" "echoes build_id"
+
+missing_artifact="$temporary_root/missing-artifact"
+build_valid_tree "$missing_artifact"
+rm -f "$missing_artifact/vdpm-0.1.0-1-x86_64-linux-gnu.pkg.tar.xz"
+assert_fails "missing artifact" "$missing_artifact" \
+	"missing declared artifacts: vdpm-0.1.0-1-x86_64-linux-gnu.pkg.tar.xz"
+
+extra_file="$temporary_root/extra-file"
+build_valid_tree "$extra_file"
+printf 'surprise\n' > "$extra_file/unexpected-file.txt"
+assert_fails "undeclared file" "$extra_file" "undeclared files present: unexpected-file.txt"
+
+bad_checksum="$temporary_root/bad-checksum"
+build_valid_tree "$bad_checksum"
+printf 'tampered\n' > "$bad_checksum/vitasdk-core-0.1-1-x86_64-linux-gnu.pkg.tar.xz"
+assert_fails "checksum mismatch" "$bad_checksum" "checksum mismatch for vitasdk-core-0.1-1-x86_64-linux-gnu.pkg.tar.xz"
+
+path_traversal="$temporary_root/path-traversal"
+build_valid_tree "$path_traversal"
+edit_manifest "$path_traversal" 'data["hosts"][0]["artifacts"][2] = "../escape"'
+assert_fails "path traversal artifact" "$path_traversal" "not a safe relative path"
+
+nested_dir="$temporary_root/nested-dir"
+build_valid_tree "$nested_dir"
+mkdir "$nested_dir/subdir"
+assert_fails "nested directory" "$nested_dir" "non-regular entry: subdir"
+
+printf 'buildscripts-ci verify contract passed\n'


### PR DESCRIPTION
Second half of the CLI surface of the buildscripts protocol (spec phase 1, pure addition), on top of #154.

`./buildscripts-ci verify --tree <dir>` is the black-box gate a publisher runs over a grouped release tree before publishing it: the tree must contain exactly what its `release.json` declares — nothing missing, nothing extra, checksums in `SHA256SUMS` recomputed and matching, every per-host `build_id` echo equal to the manifest's, paths sane, tree flat. The manifest is the single source of truth (the distribution contract's "self-described by its manifest, never found by hard-coded globs"); the deep pacman-database introspection the old autobuilds validator did lives on as a test of the grouping script instead, in the reusable-workflow PR that follows this one.

The caller learns pass/fail and nothing about VitaSDK's composition. Contract tests over synthetic valid and invalid trees run in the `checks` job; the cross-check that a tree produced by the real grouping script passes this `verify` ran as part of the integration of these branches.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).
