### PR TITLE
Add the reusable staged build workflow

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -28,9 +28,6 @@ on:
 env:
   BUILDSCRIPTS_REPO: vitasdk/buildscripts
 
-concurrency:
-  group: build-sdk-${{ github.workflow }}-${{ github.run_id }}
-
 jobs:
   # Checks out the calling ref's own parser, never the lock's revision.
   gate:

--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -198,15 +198,44 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  # Fixed job, not matrixed: a real Windows bootstrap install only proves
+  # anything on a real Windows runner. scripts/ci/smoke-windows-bootstrap.ps1
+  # holds the VitaSDK-specific knowledge (host triple, install layout); it
+  # no-ops cleanly if stage3 built no Windows artifact.
+  smoke-windows-bootstrap:
+    name: Smoke test the Windows bootstrap
+    needs: [gate, stage3]
+    if: |
+      always() && needs.gate.result == 'success' &&
+      needs.stage3.result != 'failure' && needs.stage3.result != 'cancelled'
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.BUILDSCRIPTS_REPO }}
+          ref: ${{ needs.gate.outputs.buildscripts_revision }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: stage3-*
+          path: artifacts
+        # Tolerates a lock whose stage3 never touches Windows: the script,
+        # not this step, is what decides whether there is anything to test.
+        continue-on-error: true
+      - name: Exercise the Windows bootstrap if stage3 built one
+        shell: pwsh
+        run: ./scripts/ci/smoke-windows-bootstrap.ps1 -ArtifactsDir artifacts
+
   # Grouping's own runner/container are fixed: there is no "host" here.
   group:
     name: Group the release tree
-    needs: [gate, stage1, stage2, stage3]
+    needs: [gate, stage1, stage2, stage3, smoke-windows-bootstrap]
     if: |
       always() && needs.gate.result == 'success' &&
       needs.stage1.result != 'failure' && needs.stage1.result != 'cancelled' &&
       needs.stage2.result != 'failure' && needs.stage2.result != 'cancelled' &&
-      needs.stage3.result != 'failure' && needs.stage3.result != 'cancelled'
+      needs.stage3.result != 'failure' && needs.stage3.result != 'cancelled' &&
+      needs['smoke-windows-bootstrap'].result != 'failure' && needs['smoke-windows-bootstrap'].result != 'cancelled'
     runs-on: ubuntu-24.04
     outputs:
       build_id: ${{ needs.gate.outputs.build_id }}

--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -1,0 +1,265 @@
+name: Build SDK (reusable)
+
+# Generic staged executor (spec: "2. build -- the reusable workflow"). Zero
+# VitaSDK knowledge here: every matrix and command comes from the lock or
+# from the buildscripts revision it names, via scripts/ci/build-host.sh.
+
+on:
+  workflow_call:
+    inputs:
+      lock:
+        description: The JSON lock produced by `describe`
+        required: true
+        type: string
+    outputs:
+      build_id:
+        description: The lock's build_id, echoed back for convenience
+        value: ${{ jobs.group.outputs.build_id }}
+      release_tree_artifact:
+        description: Name of the uploaded grouped release tree artifact
+        value: ${{ jobs.group.outputs.release_tree_artifact }}
+  workflow_dispatch:
+    inputs:
+      lock:
+        description: The JSON lock produced by `describe` (paste verbatim)
+        required: true
+        type: string
+
+env:
+  BUILDSCRIPTS_REPO: vitasdk/buildscripts
+
+concurrency:
+  group: build-sdk-${{ github.workflow }}-${{ github.run_id }}
+
+jobs:
+  # Checks out the calling ref's own parser, never the lock's revision.
+  gate:
+    name: Validate the lock
+    runs-on: ubuntu-24.04
+    outputs:
+      schema: ${{ steps.parse.outputs.schema }}
+      build_id: ${{ steps.parse.outputs.build_id }}
+      buildscripts_revision: ${{ steps.parse.outputs.buildscripts_revision }}
+      profile: ${{ steps.parse.outputs.profile }}
+      version: ${{ steps.parse.outputs.version }}
+      stage1_hosts: ${{ steps.parse.outputs.stage1_hosts }}
+      stage2_hosts: ${{ steps.parse.outputs.stage2_hosts }}
+      stage3_hosts: ${{ steps.parse.outputs.stage3_hosts }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.BUILDSCRIPTS_REPO }}
+      - id: parse
+        shell: bash
+        env:
+          LOCK_JSON: ${{ inputs.lock }}
+        run: python3 scripts/ci/parse-lock.py
+
+  # Stage 1: the producer of the shared target half.
+  stage1:
+    name: stage1 (${{ matrix.name }})
+    needs: gate
+    if: needs.gate.outputs.stage1_hosts != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.gate.outputs.stage1_hosts) }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Ensure git is available for checkout
+        if: matrix.container
+        shell: bash
+        run: |
+          command -v git >/dev/null || {
+            apt-get update -qq
+            apt-get install -y -qq git ca-certificates
+          }
+          git config --global --add safe.directory '*'
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.BUILDSCRIPTS_REPO }}
+          ref: ${{ needs.gate.outputs.buildscripts_revision }}
+          fetch-depth: 0
+      - name: Build stage 1 host ${{ matrix.name }}
+        shell: bash
+        run: |
+          scripts/ci/build-host.sh \
+            --host '${{ matrix.name }}' --stage '${{ matrix.stage }}' \
+            --artifacts-dir "$PWD/artifacts" --out-dir "$PWD/out" \
+            --build-id '${{ needs.gate.outputs.build_id }}' \
+            --version '${{ needs.gate.outputs.version }}' \
+            --revision '${{ needs.gate.outputs.buildscripts_revision }}' \
+            --profile '${{ needs.gate.outputs.profile }}'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stage1-${{ matrix.name }}
+          path: out/*
+          if-no-files-found: error
+          retention-days: 14
+
+  # Stage 2: the hosts that can run what they build.
+  stage2:
+    name: stage2 (${{ matrix.name }})
+    needs: [gate, stage1]
+    if: |
+      always() && needs.gate.result == 'success' &&
+      needs.stage1.result != 'failure' && needs.stage1.result != 'cancelled' &&
+      needs.gate.outputs.stage2_hosts != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.gate.outputs.stage2_hosts) }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Ensure git is available for checkout
+        if: matrix.container
+        shell: bash
+        run: |
+          command -v git >/dev/null || {
+            apt-get update -qq
+            apt-get install -y -qq git ca-certificates
+          }
+          git config --global --add safe.directory '*'
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.BUILDSCRIPTS_REPO }}
+          ref: ${{ needs.gate.outputs.buildscripts_revision }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: stage1-*
+          path: artifacts
+      - name: Build stage 2 host ${{ matrix.name }}
+        shell: bash
+        run: |
+          scripts/ci/build-host.sh \
+            --host '${{ matrix.name }}' --stage '${{ matrix.stage }}' \
+            --artifacts-dir "$PWD/artifacts" --out-dir "$PWD/out" \
+            --build-id '${{ needs.gate.outputs.build_id }}' \
+            --version '${{ needs.gate.outputs.version }}' \
+            --revision '${{ needs.gate.outputs.buildscripts_revision }}' \
+            --profile '${{ needs.gate.outputs.profile }}'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stage2-${{ matrix.name }}
+          path: out/*
+          if-no-files-found: error
+          retention-days: 14
+
+  # Stage 3: the canadian crosses, each importing a complete stage-2 SDK.
+  stage3:
+    name: stage3 (${{ matrix.name }})
+    needs: [gate, stage2]
+    if: |
+      always() && needs.gate.result == 'success' &&
+      needs.stage2.result != 'failure' && needs.stage2.result != 'cancelled' &&
+      needs.gate.outputs.stage3_hosts != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.gate.outputs.stage3_hosts) }}
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Ensure git is available for checkout
+        if: matrix.container
+        shell: bash
+        run: |
+          command -v git >/dev/null || {
+            apt-get update -qq
+            apt-get install -y -qq git ca-certificates
+          }
+          git config --global --add safe.directory '*'
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.BUILDSCRIPTS_REPO }}
+          ref: ${{ needs.gate.outputs.buildscripts_revision }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: stage2-*
+          path: artifacts
+      - name: Build stage 3 host ${{ matrix.name }}
+        shell: bash
+        run: |
+          scripts/ci/build-host.sh \
+            --host '${{ matrix.name }}' --stage '${{ matrix.stage }}' \
+            --artifacts-dir "$PWD/artifacts" --out-dir "$PWD/out" \
+            --build-id '${{ needs.gate.outputs.build_id }}' \
+            --version '${{ needs.gate.outputs.version }}' \
+            --revision '${{ needs.gate.outputs.buildscripts_revision }}' \
+            --profile '${{ needs.gate.outputs.profile }}'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: stage3-${{ matrix.name }}
+          path: out/*
+          if-no-files-found: error
+          retention-days: 14
+
+  # Grouping's own runner/container are fixed: there is no "host" here.
+  group:
+    name: Group the release tree
+    needs: [gate, stage1, stage2, stage3]
+    if: |
+      always() && needs.gate.result == 'success' &&
+      needs.stage1.result != 'failure' && needs.stage1.result != 'cancelled' &&
+      needs.stage2.result != 'failure' && needs.stage2.result != 'cancelled' &&
+      needs.stage3.result != 'failure' && needs.stage3.result != 'cancelled'
+    runs-on: ubuntu-24.04
+    outputs:
+      build_id: ${{ needs.gate.outputs.build_id }}
+      release_tree_artifact: grouped-sdk-snapshot
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.BUILDSCRIPTS_REPO }}
+          ref: ${{ needs.gate.outputs.buildscripts_revision }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: stage1-*
+          path: artifacts
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: stage2-*
+          path: artifacts
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: stage3-*
+          path: artifacts
+      - name: Group the release tree
+        shell: bash
+        env:
+          RELEASE_SCHEMA: ${{ needs.gate.outputs.schema }}
+          RELEASE_BUILD_ID: ${{ needs.gate.outputs.build_id }}
+          RELEASE_BUILDSCRIPTS_REVISION: ${{ needs.gate.outputs.buildscripts_revision }}
+          RELEASE_PROFILE: ${{ needs.gate.outputs.profile }}
+          RELEASE_PROVENANCE_DIRECTORY: ${{ github.workspace }}/artifacts
+          SDK_ARCHIVE_DIRECTORY: ${{ github.workspace }}/artifacts
+        run: |
+          export SOURCE_DATE_EPOCH
+          SOURCE_DATE_EPOCH=$(git show -s --format=%ct HEAD)
+          docker run --rm \
+            --platform linux/amd64 \
+            --user "$(id -u):$(id -g)" \
+            --mount "type=bind,source=$PWD,target=/workspace,readonly" \
+            --mount "type=bind,source=$PWD/artifacts,target=/input,readonly" \
+            --mount "type=bind,source=$RUNNER_TEMP,target=/output" \
+            --env SOURCE_DATE_EPOCH \
+            --env RELEASE_SCHEMA --env RELEASE_BUILD_ID \
+            --env RELEASE_BUILDSCRIPTS_REVISION --env RELEASE_PROFILE \
+            --env SDK_ARCHIVE_DIRECTORY=/input \
+            --env RELEASE_PROVENANCE_DIRECTORY=/input \
+            archlinux@sha256:c1829f370be8434135f43fb3acaef1256780804ac3b2d2eec90dfb1232e1ffdf \
+            bash -euc '
+              /workspace/scripts/create-core-repositories.sh \
+                /output/repository /input/*/*.pkg.tar.xz
+            '
+      - uses: actions/upload-artifact@v7
+        with:
+          name: grouped-sdk-snapshot
+          path: ${{ runner.temp }}/repository/*
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -90,7 +90,8 @@ jobs:
             --build-id '${{ needs.gate.outputs.build_id }}' \
             --version '${{ needs.gate.outputs.version }}' \
             --revision '${{ needs.gate.outputs.buildscripts_revision }}' \
-            --profile '${{ needs.gate.outputs.profile }}'
+            --profile '${{ needs.gate.outputs.profile }}' \
+            --packaged '${{ matrix.packaged }}' --build-host '${{ matrix.build_host }}'
       - uses: actions/upload-artifact@v7
         with:
           name: stage1-${{ matrix.name }}
@@ -140,7 +141,8 @@ jobs:
             --build-id '${{ needs.gate.outputs.build_id }}' \
             --version '${{ needs.gate.outputs.version }}' \
             --revision '${{ needs.gate.outputs.buildscripts_revision }}' \
-            --profile '${{ needs.gate.outputs.profile }}'
+            --profile '${{ needs.gate.outputs.profile }}' \
+            --packaged '${{ matrix.packaged }}' --build-host '${{ matrix.build_host }}'
       - uses: actions/upload-artifact@v7
         with:
           name: stage2-${{ matrix.name }}
@@ -190,7 +192,8 @@ jobs:
             --build-id '${{ needs.gate.outputs.build_id }}' \
             --version '${{ needs.gate.outputs.version }}' \
             --revision '${{ needs.gate.outputs.buildscripts_revision }}' \
-            --profile '${{ needs.gate.outputs.profile }}'
+            --profile '${{ needs.gate.outputs.profile }}' \
+            --packaged '${{ matrix.packaged }}' --build-host '${{ matrix.build_host }}'
       - uses: actions/upload-artifact@v7
         with:
           name: stage3-${{ matrix.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,12 @@ jobs:
           echo "== $test"
           "$test"
         done
+    - name: Run the reusable workflow tests
+      run: |
+        for test in tests/ci/test-*.sh; do
+          echo "== $test"
+          "$test"
+        done
 
   # ---------------------------------------------------------------------
   # Stage 1: the only job that compiles target code, and it compiles

--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Entry point the reusable build workflow invokes for one (stage, host) pair.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+# shellcheck source=scripts/ci/lib.sh
+source "$repo_root/scripts/ci/lib.sh"
+
+host=""
+stage=""
+artifacts_dir=""
+out_dir=""
+build_id=""
+version=""
+revision=""
+profile=""
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+	--host)
+		host=$2
+		shift 2
+		;;
+	--stage)
+		stage=$2
+		shift 2
+		;;
+	--artifacts-dir)
+		artifacts_dir=$2
+		shift 2
+		;;
+	--out-dir)
+		out_dir=$2
+		shift 2
+		;;
+	--build-id)
+		build_id=$2
+		shift 2
+		;;
+	--version)
+		version=$2
+		shift 2
+		;;
+	--revision)
+		revision=$2
+		shift 2
+		;;
+	--profile)
+		profile=$2
+		shift 2
+		;;
+	*)
+		printf 'unknown argument: %s\n' "$1" >&2
+		exit 2
+		;;
+	esac
+done
+for required in host stage artifacts_dir out_dir build_id version revision profile; do
+	[[ -n ${!required} ]] || {
+		printf -- '--%s is required\n' "${required//_/-}" >&2
+		exit 2
+	}
+done
+# profile is required but not yet consumed: no profile -> VITASDK_FLOAT_ABI
+# mapping exists in CMakeLists.txt yet.
+: "$profile"
+
+actual_revision=$(git -C "$repo_root" rev-parse HEAD)
+[[ $actual_revision == "$revision" ]] || {
+	printf 'checked out %s but the lock names %s\n' "$actual_revision" "$revision" >&2
+	exit 1
+}
+source_date_epoch=$(git -C "$repo_root" show -s --format=%ct HEAD)
+
+mkdir -p "$out_dir"
+export LANG=C.UTF-8
+git config --global user.email "builds@ci.invalid"
+git config --global user.name "buildscripts CI"
+
+# Hosts that publish an installable core package (spec: "Supported host build
+# transaction"); every other buildable host still gets a plain SDK tarball.
+is_required_host() {
+	case $1 in
+	x86_64-linux-gnu | aarch64-linux-gnu | arm64-apple-darwin | x86_64-w64-mingw32) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+vdpm_tag() {
+	sed -n 's/^set(VDPM_TAG \([^ )]*\).*/\1/p' "$repo_root/cmake/Components.cmake"
+}
+
+# Sets vdpm_bundle/vdpm_bundle_sha256. Verified against the release's own
+# sidecar checksum, not a hash pinned in Components.cmake (source pinning is
+# out of this workflow's scope).
+download_vdpm_bundle() {
+	local vdpm_host=$1 dest_dir=$2 tag archive base actual sidecar
+	mkdir -p "$dest_dir"
+	tag=$(vdpm_tag)
+	archive="vdpm-${tag#v}-$vdpm_host.tar.bz2"
+	base="https://github.com/vitasdk/vdpm/releases/download/$tag"
+	curl -fsSL --retry 3 -o "$dest_dir/$archive" "$base/$archive"
+	curl -fsSL --retry 3 -o "$dest_dir/$archive.sha256" "$base/$archive.sha256"
+	actual=$(ci_sha256 "$dest_dir/$archive")
+	sidecar=$(awk '{print $1}' "$dest_dir/$archive.sha256")
+	[[ $actual == "$sidecar" ]] || {
+		printf 'vdpm bundle hash mismatch for %s\n' "$vdpm_host" >&2
+		return 1
+	}
+	vdpm_bundle="$dest_dir/$archive"
+	vdpm_bundle_sha256=$actual
+}
+
+# Same-runner smoke test only; a canadian cross cannot run what it built.
+smoke_test_bootstrap() {
+	local bootstrap_archive=$1 digest install_root
+	digest=$(awk '{print $1}' "$bootstrap_archive.sha256")
+	install_root="$PWD/bootstrap-installed"
+	VITASDK_BOOTSTRAP_ARCHIVE="$bootstrap_archive" VITASDK_BOOTSTRAP_SHA256="$digest" \
+		build/vitasdk/share/vdpm/bootstrap-vitasdk.sh --install-dir "$install_root"
+	VITASDK="$install_root" "$install_root/bin/vdpm" --help >/dev/null
+	# vdpm ships pacman under libexec/vdpm, not bin/.
+	"$install_root/libexec/vdpm/pacman" --version >/dev/null
+	"$install_root/bin/arm-vita-eabi-gcc" --version
+}
+
+# Builds against $stage1_dir if set, then stages outputs plus provenance.
+build_and_stage() {
+	local -a extra_args=("$@")
+	local -a cmake_args=(
+		-S "$repo_root" -B build "${extra_args[@]}"
+		-DVITASDK_SOURCE_REVISION="$revision"
+		-DVITASDK_SOURCE_DATE_EPOCH="$source_date_epoch"
+	)
+	[[ -n ${stage1_dir:-} ]] && cmake_args+=(-DVITASDK_STAGE1_DIR="$stage1_dir")
+	local -a targets=(tarball)
+
+	local vdpm_bundle="" vdpm_bundle_sha256=""
+	if is_required_host "$host"; then
+		download_vdpm_bundle "$host" "$PWD/vdpm-release"
+		cmake_args+=(
+			-DBUILD_PACMAN_CLIENT=ON
+			-DVITASDK_PACKAGE_VERSION="$version"
+			-DVDPM_BUNDLE="$vdpm_bundle"
+			-DVDPM_BUNDLE_SHA256="$vdpm_bundle_sha256"
+		)
+		targets+=(core-package bootstrap-archive)
+	fi
+
+	cmake "${cmake_args[@]}"
+	cmake --build build --target "${targets[@]}" --parallel "$(ci_nproc)"
+
+	# Only a native build can run its own output.
+	if [[ -z ${build_sdk_host:-} ]]; then
+		cmake --build build --target check-toolchain-contract
+		if is_required_host "$host"; then
+			smoke_test_bootstrap "build/bootstraps/vitasdk-bootstrap-$host.tar.bz2"
+		fi
+	fi
+
+	local -a produced=(build/vitasdk-*.tar.bz2)
+	if is_required_host "$host"; then
+		produced+=(build/packages/*.pkg.tar.xz build/bootstraps/vitasdk-bootstrap-*.tar.bz2 build/bootstraps/vitasdk-bootstrap-*.tar.bz2.sha256)
+	fi
+	local -a names=()
+	local file
+	for file in "${produced[@]}"; do
+		[[ -f $file ]] || continue
+		cp "$file" "$out_dir/"
+		names+=("$(basename "$file")")
+	done
+	ci_write_provenance "$out_dir" "$host" "$build_id" "${names[@]}"
+}
+
+# musl hosts are native builds inside Alpine (see build.yml stage2-musl).
+build_musl_host() {
+	docker run --rm \
+		-v "$PWD":/src -w /src \
+		-e VITASDK_SOURCE_REVISION="$revision" \
+		-e VITASDK_SOURCE_DATE_EPOCH="$source_date_epoch" \
+		alpine:3.20 sh -eux -c '
+			apk add --no-cache bash build-base cmake git autoconf automake \
+				libtool texinfo bison flex pkgconf curl xz python3 bzip2 \
+				tar linux-headers
+			git config --global --add safe.directory "*"
+			git config --global user.email "builds@ci.invalid"
+			git config --global user.name "buildscripts CI"
+			STAGE1_DIR=$(dirname "$(dirname "$(dirname "$(find /src/stage1 -type f -path "*/arm-vita-eabi/lib/libc.a" | head -1)")")")
+			test -n "$STAGE1_DIR"
+			mkdir -p /src/build
+			cd /src/build
+			cmake /src -DVITASDK_STAGE1_DIR="$STAGE1_DIR" \
+				-DVITASDK_SOURCE_REVISION="$VITASDK_SOURCE_REVISION" \
+				-DVITASDK_SOURCE_DATE_EPOCH="$VITASDK_SOURCE_DATE_EPOCH"
+			make -j"$(getconf _NPROCESSORS_ONLN)" tarball
+			make check-toolchain-contract
+		'
+	local -a produced=(build/vitasdk-*.tar.bz2)
+	local -a names=()
+	local file
+	for file in "${produced[@]}"; do
+		[[ -f $file ]] || continue
+		cp "$file" "$out_dir/"
+		names+=("$(basename "$file")")
+	done
+	ci_write_provenance "$out_dir" "$host" "$build_id" "${names[@]}"
+}
+
+install_dependencies() {
+	local sudo_cmd=()
+	[[ $(id -u) == 0 ]] || sudo_cmd=(sudo)
+	case "$(uname -s)" in
+	Darwin)
+		brew install autoconf automake libtool texinfo
+		;;
+	Linux)
+		local -a extra=()
+		case $host in
+		x86_64-w64-mingw32) extra=(g++-mingw-w64-x86-64) ;;
+		i686-w64-mingw32) extra=(g++-mingw-w64-i686) ;;
+		x86_64-unknown-freebsd | aarch64-unknown-freebsd) extra=(clang lld llvm) ;;
+		esac
+		"${sudo_cmd[@]}" apt-get update -qq
+		"${sudo_cmd[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+			cmake cmake-data git build-essential autoconf automake libtool \
+			texinfo bison flex pkg-config python3 python3-pip curl bzip2 xz-utils \
+			"${extra[@]}"
+		pip3 install --quiet cmake==3.31.6
+		;;
+	esac
+}
+
+if [[ $stage == 1 ]]; then
+	# Dispatch is on stage, not host name: the lock may reuse a name here
+	# (e.g. x86_64-linux-gnu) that also appears at stage 2.
+	install_dependencies
+	cmake -S "$repo_root" -B build \
+		-DVITASDK_TARGET_ONLY=ON \
+		-DVITASDK_SOURCE_REVISION="$revision" \
+		-DVITASDK_SOURCE_DATE_EPOCH="$source_date_epoch"
+	cmake --build build --target sysroot --parallel "$(ci_nproc)"
+	cp build/vitasdk-sysroot-*.tar.bz2 "$out_dir/"
+	ci_write_provenance "$out_dir" "$host" "$build_id" "$(basename build/vitasdk-sysroot-*.tar.bz2)"
+	exit 0
+fi
+
+if [[ $host == *-linux-musl ]]; then
+	stage1_source_dir=$(ci_find_stage_artifact "$artifacts_dir" 1 '*') ||
+		{
+			printf 'stage1 artifact not found under %s\n' "$artifacts_dir" >&2
+			exit 1
+		}
+	ci_unpack_sdk_artifact "$stage1_source_dir" "$PWD/stage1"
+	build_musl_host
+	exit 0
+fi
+
+extra_cmake_args=()
+build_sdk_host=""
+case $host in
+x86_64-linux-gnu | aarch64-linux-gnu | arm64-apple-darwin)
+	install_dependencies
+	;;
+x86_64-w64-mingw32)
+	install_dependencies
+	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/x86_64-w64-mingw32.cmake")
+	build_sdk_host=x86_64-linux-gnu
+	;;
+i686-w64-mingw32)
+	install_dependencies
+	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/i686-w64-mingw32.cmake")
+	build_sdk_host=x86_64-linux-gnu
+	;;
+x86_64-unknown-freebsd)
+	install_dependencies
+	scripts/setup-freebsd-cross.sh 14.3 "$PWD/freebsd-cross" x86_64
+	export PATH="$PWD/freebsd-cross/bin:$PATH"
+	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/x86_64-unknown-freebsd.cmake")
+	build_sdk_host=x86_64-linux-gnu
+	;;
+aarch64-unknown-freebsd)
+	install_dependencies
+	scripts/setup-freebsd-cross.sh 14.3 "$PWD/freebsd-cross" aarch64
+	export PATH="$PWD/freebsd-cross/bin:$PATH"
+	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/aarch64-unknown-freebsd.cmake")
+	build_sdk_host=x86_64-linux-gnu
+	;;
+x86_64-apple-darwin)
+	install_dependencies
+	scripts/setup-macos-cross.sh "$PWD/macos-cross"
+	export PATH="$PWD/macos-cross/bin:$PATH"
+	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/x86_64-apple-darwin.cmake")
+	build_sdk_host=arm64-apple-darwin
+	;;
+*)
+	printf 'no build recipe for host: %s\n' "$host" >&2
+	exit 1
+	;;
+esac
+
+if [[ $stage == 2 ]]; then
+	# Whichever host name produced stage 1 -- see the dispatch note above.
+	stage1_source_dir=$(ci_find_stage_artifact "$artifacts_dir" 1 '*') ||
+		{
+			printf 'stage1 artifact not found under %s\n' "$artifacts_dir" >&2
+			exit 1
+		}
+	ci_unpack_sdk_artifact "$stage1_source_dir" "$PWD/stage1"
+	stage1_dir=$(ci_find_sdk_root "$PWD/stage1")
+else
+	# Always stage 2 (a full SDK, with arm-vita-eabi-gcc for -dumpspecs),
+	# even for a host name that also has a stage-1 entry.
+	[[ -n $build_sdk_host ]] || {
+		printf 'stage 3 host %s has no build-machine mapping\n' "$host" >&2
+		exit 1
+	}
+	build_sdk_source_dir=$(ci_find_stage_artifact "$artifacts_dir" 2 "$build_sdk_host") ||
+		{
+			printf 'no build-machine SDK found for %s (needs %s)\n' "$host" "$build_sdk_host" >&2
+			exit 1
+		}
+	ci_unpack_sdk_artifact "$build_sdk_source_dir" "$PWD/build-sdk"
+	stage1_dir=$(ci_find_sdk_root "$PWD/build-sdk")
+	export PATH="$stage1_dir/bin:$PATH"
+fi
+
+build_and_stage "${extra_cmake_args[@]}"

--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -173,6 +173,18 @@ build_and_stage() {
 		cp "$file" "$out_dir/"
 		names+=("$(basename "$file")")
 	done
+	# The globs skip silently, so a packaged host that produced nothing of a
+	# family would otherwise publish a quietly incomplete provenance.
+	if is_packaged_host; then
+		local pattern
+		for pattern in 'vitasdk-core-*.pkg.tar.xz' 'vdpm-*.pkg.tar.xz' \
+			"vitasdk-bootstrap-$host.tar.bz2" "vitasdk-bootstrap-$host.tar.bz2.sha256"; do
+			printf '%s\n' "${names[@]}" | grep -x -- "${pattern//\*/.*}" >/dev/null || {
+				printf 'packaged host %s produced no %s\n' "$host" "$pattern" >&2
+				exit 1
+			}
+		done
+	fi
 	ci_write_provenance "$out_dir" "$host" "$build_id" "${names[@]}"
 }
 
@@ -249,6 +261,12 @@ if [[ $stage == 1 ]]; then
 fi
 
 if [[ $host == *-linux-musl ]]; then
+	# The musl path builds only the SDK tarball; flipping packaged on must
+	# fail here rather than publish a host with no packages or bootstrap.
+	if is_packaged_host; then
+		printf 'packaged musl hosts are not implemented\n' >&2
+		exit 1
+	fi
 	stage1_source_dir=$(ci_find_stage_artifact "$artifacts_dir" 1 '*') ||
 		{
 			printf 'stage1 artifact not found under %s\n' "$artifacts_dir" >&2

--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -14,6 +14,8 @@ build_id=""
 version=""
 revision=""
 profile=""
+packaged=""
+build_host=""
 
 while [[ $# -gt 0 ]]; do
 	case $1 in
@@ -49,13 +51,21 @@ while [[ $# -gt 0 ]]; do
 		profile=$2
 		shift 2
 		;;
+	--packaged)
+		packaged=$2
+		shift 2
+		;;
+	--build-host)
+		build_host=$2
+		shift 2
+		;;
 	*)
 		printf 'unknown argument: %s\n' "$1" >&2
 		exit 2
 		;;
 	esac
 done
-for required in host stage artifacts_dir out_dir build_id version revision profile; do
+for required in host stage artifacts_dir out_dir build_id version revision profile packaged; do
 	[[ -n ${!required} ]] || {
 		printf -- '--%s is required\n' "${required//_/-}" >&2
 		exit 2
@@ -77,14 +87,8 @@ export LANG=C.UTF-8
 git config --global user.email "builds@ci.invalid"
 git config --global user.name "buildscripts CI"
 
-# Hosts that publish an installable core package (spec: "Supported host build
-# transaction"); every other buildable host still gets a plain SDK tarball.
-is_required_host() {
-	case $1 in
-	x86_64-linux-gnu | aarch64-linux-gnu | arm64-apple-darwin | x86_64-w64-mingw32) return 0 ;;
-	*) return 1 ;;
-	esac
-}
+# The matrix's packaged flag, not the host name, gates core-package treatment.
+is_packaged_host() { [[ $packaged == true ]]; }
 
 vdpm_tag() {
 	sed -n 's/^set(VDPM_TAG \([^ )]*\).*/\1/p' "$repo_root/cmake/Components.cmake"
@@ -136,7 +140,7 @@ build_and_stage() {
 	local -a targets=(tarball)
 
 	local vdpm_bundle="" vdpm_bundle_sha256=""
-	if is_required_host "$host"; then
+	if is_packaged_host; then
 		download_vdpm_bundle "$host" "$PWD/vdpm-release"
 		cmake_args+=(
 			-DBUILD_PACMAN_CLIENT=ON
@@ -151,15 +155,15 @@ build_and_stage() {
 	cmake --build build --target "${targets[@]}" --parallel "$(ci_nproc)"
 
 	# Only a native build can run its own output.
-	if [[ -z ${build_sdk_host:-} ]]; then
+	if [[ -z $build_host ]]; then
 		cmake --build build --target check-toolchain-contract
-		if is_required_host "$host"; then
+		if is_packaged_host; then
 			smoke_test_bootstrap "build/bootstraps/vitasdk-bootstrap-$host.tar.bz2"
 		fi
 	fi
 
 	local -a produced=(build/vitasdk-*.tar.bz2)
-	if is_required_host "$host"; then
+	if is_packaged_host; then
 		produced+=(build/packages/*.pkg.tar.xz build/bootstraps/vitasdk-bootstrap-*.tar.bz2 build/bootstraps/vitasdk-bootstrap-*.tar.bz2.sha256)
 	fi
 	local -a names=()
@@ -256,7 +260,6 @@ if [[ $host == *-linux-musl ]]; then
 fi
 
 extra_cmake_args=()
-build_sdk_host=""
 case $host in
 x86_64-linux-gnu | aarch64-linux-gnu | arm64-apple-darwin)
 	install_dependencies
@@ -264,33 +267,28 @@ x86_64-linux-gnu | aarch64-linux-gnu | arm64-apple-darwin)
 x86_64-w64-mingw32)
 	install_dependencies
 	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/x86_64-w64-mingw32.cmake")
-	build_sdk_host=x86_64-linux-gnu
 	;;
 i686-w64-mingw32)
 	install_dependencies
 	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/i686-w64-mingw32.cmake")
-	build_sdk_host=x86_64-linux-gnu
 	;;
 x86_64-unknown-freebsd)
 	install_dependencies
 	scripts/setup-freebsd-cross.sh 14.3 "$PWD/freebsd-cross" x86_64
 	export PATH="$PWD/freebsd-cross/bin:$PATH"
 	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/x86_64-unknown-freebsd.cmake")
-	build_sdk_host=x86_64-linux-gnu
 	;;
 aarch64-unknown-freebsd)
 	install_dependencies
 	scripts/setup-freebsd-cross.sh 14.3 "$PWD/freebsd-cross" aarch64
 	export PATH="$PWD/freebsd-cross/bin:$PATH"
 	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/aarch64-unknown-freebsd.cmake")
-	build_sdk_host=x86_64-linux-gnu
 	;;
 x86_64-apple-darwin)
 	install_dependencies
 	scripts/setup-macos-cross.sh "$PWD/macos-cross"
 	export PATH="$PWD/macos-cross/bin:$PATH"
 	extra_cmake_args+=(-DCMAKE_TOOLCHAIN_FILE="$repo_root/cmake/toolchains/x86_64-apple-darwin.cmake")
-	build_sdk_host=arm64-apple-darwin
 	;;
 *)
 	printf 'no build recipe for host: %s\n' "$host" >&2
@@ -309,14 +307,15 @@ if [[ $stage == 2 ]]; then
 	stage1_dir=$(ci_find_sdk_root "$PWD/stage1")
 else
 	# Always stage 2 (a full SDK, with arm-vita-eabi-gcc for -dumpspecs),
-	# even for a host name that also has a stage-1 entry.
-	[[ -n $build_sdk_host ]] || {
+	# even for a host name that also has a stage-1 entry. build_host comes
+	# from the lock (cmake/hosts.json), not a hardcoded per-host table.
+	[[ -n $build_host ]] || {
 		printf 'stage 3 host %s has no build-machine mapping\n' "$host" >&2
 		exit 1
 	}
-	build_sdk_source_dir=$(ci_find_stage_artifact "$artifacts_dir" 2 "$build_sdk_host") ||
+	build_sdk_source_dir=$(ci_find_stage_artifact "$artifacts_dir" 2 "$build_host") ||
 		{
-			printf 'no build-machine SDK found for %s (needs %s)\n' "$host" "$build_sdk_host" >&2
+			printf 'no build-machine SDK found for %s (needs %s)\n' "$host" "$build_host" >&2
 			exit 1
 		}
 	ci_unpack_sdk_artifact "$build_sdk_source_dir" "$PWD/build-sdk"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Shared helpers for the reusable build workflow's entry-point scripts.
+
+ci_sha256() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+	else
+		shasum -a 256 "$1" | awk '{print $1}'
+	fi
+}
+
+ci_nproc() {
+	if [[ $(uname -s) == Darwin ]]; then
+		sysctl -n hw.logicalcpu
+	else
+		nproc
+	fi
+}
+
+# Locates the root of an unpacked SDK/sysroot tree via its target payload.
+ci_find_sdk_root() {
+	local search_root=$1 marker
+	marker=$(find "$search_root" -type f -path '*/arm-vita-eabi/lib/libc.a' | head -1)
+	[[ -n $marker ]] || {
+		printf 'no unpacked SDK found under %s\n' "$search_root" >&2
+		return 1
+	}
+	dirname "$(dirname "$(dirname "$marker")")"
+}
+
+ci_unpack_sdk_artifact() {
+	local artifact_dir=$1 destination=$2
+	mkdir -p "$destination"
+	local archive=""
+	for candidate in "$artifact_dir"/*.tar.bz2; do
+		[[ -f $candidate ]] && archive=$candidate && break
+	done
+	[[ -n $archive ]] || {
+		printf 'no .tar.bz2 archive found in %s\n' "$artifact_dir" >&2
+		return 1
+	}
+	tar -xjf "$archive" -C "$destination"
+}
+
+# Finds the artifact dir for a (stage, host name) pair; name_glob may be '*'.
+# Stage is required: a lock may reuse one host name at several stages.
+ci_find_stage_artifact() {
+	local artifacts_dir=$1 stage=$2 name_glob=$3
+	local candidate
+	for candidate in "$artifacts_dir"/stage"$stage"-$name_glob; do
+		[[ -d $candidate ]] && printf '%s\n' "$candidate" && return 0
+	done
+	return 1
+}
+
+# Echoes build_id plus produced filenames for the grouping job to read back.
+ci_write_provenance() {
+	local out_dir=$1 host=$2 build_id=$3
+	shift 3
+	python3 - "$out_dir/provenance.json" "$host" "$build_id" "$@" <<'PY'
+import json
+import sys
+
+out_path, host, build_id, *artifacts = sys.argv[1:]
+with open(out_path, "w", encoding="utf-8") as handle:
+    json.dump(
+        {"host": host, "build_id": build_id, "artifacts": artifacts},
+        handle, indent=2, sort_keys=True,
+    )
+    handle.write("\n")
+PY
+}

--- a/scripts/ci/parse-lock.py
+++ b/scripts/ci/parse-lock.py
@@ -78,6 +78,8 @@ def main():
             "stage": stage,
             "runner": runner,
             "container": host.get("container") or "",
+            "packaged": bool(host.get("packaged")),
+            "build_host": host.get("build_host") or "",
         })
 
     write_output("schema", str(schema))

--- a/scripts/ci/parse-lock.py
+++ b/scripts/ci/parse-lock.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Gate step for the reusable build workflow: validates the lock's schema
+and groups hosts[] by stage."""
+import json
+import os
+import sys
+
+SUPPORTED_SCHEMA = 1
+SUPPORTED_STAGES = (1, 2, 3)
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def write_output(name, value):
+    path = os.environ["GITHUB_OUTPUT"]
+    delimiter = f"__parse_lock_{name}__"
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
+
+
+def main():
+    raw = os.environ.get("LOCK_JSON", "")
+    try:
+        lock = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        fail(f"lock input is not valid JSON: {exc}")
+        return
+
+    if not isinstance(lock, dict):
+        fail("lock input must be a JSON object")
+
+    schema = lock.get("schema")
+    if schema != SUPPORTED_SCHEMA:
+        fail(
+            "unsupported lock schema: this shell supports schema "
+            f"{SUPPORTED_SCHEMA}, the lock declares schema {schema!r}"
+        )
+
+    for field in ("build_id", "buildscripts_revision", "profile", "version"):
+        if not isinstance(lock.get(field), str) or not lock[field]:
+            fail(f"lock is missing required string field: {field}")
+
+    revision = lock["buildscripts_revision"]
+    if len(revision) != 40 or any(c not in "0123456789abcdefABCDEF" for c in revision):
+        fail(f"buildscripts_revision is not a 40-character git SHA: {revision!r}")
+
+    hosts = lock.get("hosts")
+    if not isinstance(hosts, list) or not hosts:
+        fail("lock carries no hosts[]")
+        return
+
+    by_stage = {stage: [] for stage in SUPPORTED_STAGES}
+    # A name may legitimately recur across stages; only the pair is unique.
+    seen_pairs = set()
+    for host in hosts:
+        if not isinstance(host, dict):
+            fail(f"malformed host entry: {host!r}")
+        name = host.get("name")
+        stage = host.get("stage")
+        runner = host.get("runner")
+        if not isinstance(name, str) or not name:
+            fail(f"host entry has no name: {host!r}")
+        if (name, stage) in seen_pairs:
+            fail(f"duplicate (name, stage) pair in lock: ({name}, {stage})")
+        seen_pairs.add((name, stage))
+        if stage not in SUPPORTED_STAGES:
+            fail(
+                f"host {name!r} declares stage {stage!r}, which schema "
+                f"{SUPPORTED_SCHEMA} does not define (supported: {SUPPORTED_STAGES})"
+            )
+        if not isinstance(runner, str) or not runner:
+            fail(f"host {name!r} has no runner")
+        by_stage[stage].append({
+            "name": name,
+            "stage": stage,
+            "runner": runner,
+            "container": host.get("container") or "",
+        })
+
+    write_output("schema", str(schema))
+    write_output("build_id", lock["build_id"])
+    write_output("buildscripts_revision", revision)
+    write_output("profile", lock["profile"])
+    write_output("version", lock["version"])
+    for stage in SUPPORTED_STAGES:
+        write_output(f"stage{stage}_hosts", json.dumps(by_stage[stage]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/smoke-windows-bootstrap.ps1
+++ b/scripts/ci/smoke-windows-bootstrap.ps1
@@ -1,0 +1,57 @@
+# Windows-on-Windows bootstrap smoke test: the host triple, on-disk layout
+# and vdpm frontend knowledge live here so build-sdk.yml stays generic.
+param(
+	[Parameter(Mandatory = $true)]
+	[string]$ArtifactsDir
+)
+
+$ErrorActionPreference = 'Stop'
+$windowsHost = 'x86_64-w64-mingw32'
+
+$archives = @()
+if (Test-Path $ArtifactsDir) {
+	$archives = @(Get-ChildItem $ArtifactsDir -Recurse -File -Filter "vitasdk-bootstrap-$windowsHost.tar.bz2")
+}
+if ($archives.Count -eq 0) {
+	Write-Host "no $windowsHost bootstrap artifact found under $ArtifactsDir; nothing to smoke test"
+	exit 0
+}
+if ($archives.Count -gt 1) {
+	throw "expected exactly one $windowsHost bootstrap archive, found $($archives.Count)"
+}
+$archive = $archives[0].FullName
+$checksumFile = "$archive.sha256"
+if (-not (Test-Path $checksumFile)) {
+	throw "missing checksum sidecar: $checksumFile"
+}
+$checksum = Get-Content $checksumFile
+$digest = ($checksum -split '\s+')[0]
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+$componentsFile = Join-Path $repoRoot 'cmake/Components.cmake'
+$vdpmTagMatch = Select-String -Path $componentsFile -Pattern '^set\(VDPM_TAG\s+([^\s)]+)' | Select-Object -First 1
+if (-not $vdpmTagMatch) {
+	throw "could not determine VDPM_TAG from $componentsFile"
+}
+$vdpmTag = $vdpmTagMatch.Matches[0].Groups[1].Value
+
+$tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$vdpmCheckout = Join-Path $tempRoot "vdpm-bootstrap-$([guid]::NewGuid())"
+git clone --depth=1 --branch $vdpmTag https://github.com/vitasdk/vdpm.git $vdpmCheckout
+if ($LASTEXITCODE -ne 0) { throw 'failed to check out the vdpm frontend' }
+
+$installRoot = Join-Path $tempRoot "vitasdk-bootstrap-installed-$([guid]::NewGuid())"
+& (Join-Path $vdpmCheckout 'bootstrap-vitasdk.ps1') `
+	-ArchivePath $archive -Sha256 $digest -InstallDirectory $installRoot
+if ($LASTEXITCODE -ne 0) { throw 'bootstrap-vitasdk.ps1 failed' }
+
+& (Join-Path $installRoot 'bin/vdpm.exe') --help | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'vdpm self-test failed' }
+
+& (Join-Path $installRoot 'share/vdpm/msys/usr/bin/pacman.exe') --version | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'pacman self-test failed' }
+
+& (Join-Path $installRoot 'bin/arm-vita-eabi-gcc.exe') --version
+if ($LASTEXITCODE -ne 0) { throw 'compiler self-test failed' }
+
+Write-Host "Windows bootstrap smoke test passed for $windowsHost"

--- a/scripts/create-core-repositories.sh
+++ b/scripts/create-core-repositories.sh
@@ -214,7 +214,7 @@ fi
 	while IFS= read -r asset; do
 		sha256sum -- "$asset"
 	done < <(
-		find . -maxdepth 1 -type f ! -name SHA256SUMS ! -name release.json -printf '%P\n' |
+		find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\n' |
 			LC_ALL=C sort
 	) >SHA256SUMS
 )

--- a/scripts/create-core-repositories.sh
+++ b/scripts/create-core-repositories.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Groups per-host vitasdk-core/vdpm packages into Pacman repositories.
+# Ported from vitasdk/autobuilds; with the RELEASE_* variables set, also
+# writes release.json in the shape `verify` (next-refactor-verify) expects.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+	printf 'usage: %s <output-directory> <vitasdk-core-package>...\n' "$0" >&2
+	exit 2
+fi
+
+output_directory=$1
+shift
+source_date_epoch=${SOURCE_DATE_EPOCH:-}
+
+[[ -n $source_date_epoch && $source_date_epoch =~ ^[0-9]+$ ]] || {
+	printf 'SOURCE_DATE_EPOCH must be set to a non-negative integer\n' >&2
+	exit 1
+}
+[[ ! -e $output_directory ]] || {
+	printf 'output path already exists: %s\n' "$output_directory" >&2
+	exit 1
+}
+command -v repo-add >/dev/null
+command -v bsdtar >/dev/null
+
+output_parent=$(cd "$(dirname "$output_directory")" && pwd -P)
+output_name=$(basename "$output_directory")
+staging_directory=$(mktemp -d "$output_parent/.${output_name}.XXXXXXXX")
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/vitasdk-core-repositories.XXXXXXXX")
+cleanup() {
+	rm -rf -- "$staging_directory" "$temporary_directory"
+}
+trap cleanup EXIT
+
+declare -A architectures=()
+declare -A names=()
+for package in "$@"; do
+	[[ -f $package && ! -L $package ]] || {
+		printf 'core package is not a regular file: %s\n' "$package" >&2
+		exit 1
+	}
+	package_filename=${package##*/}
+	pkginfo=$(bsdtar -xOf "$package" .PKGINFO)
+	pkgname=$(awk -F ' = ' '$1 == "pkgname" { print $2; exit }' <<<"$pkginfo")
+	pkgver=$(awk -F ' = ' '$1 == "pkgver" { print $2; exit }' <<<"$pkginfo")
+	architecture=$(awk -F ' = ' '$1 == "arch" { print $2; exit }' <<<"$pkginfo")
+	# A core release is the toolchain and the client that installs it, so a
+	# host repository holds both and neither may appear twice.
+	[[ ($pkgname == vitasdk-core || $pkgname == vdpm) && -n $pkgver && -n $architecture ]] || {
+		printf 'invalid core package metadata: %s\n' "$package_filename" >&2
+		exit 1
+	}
+	[[ $package_filename == "$pkgname-$pkgver-$architecture.pkg.tar."* ]] || {
+		printf 'core package filename does not match metadata: %s\n' \
+			"$package_filename" >&2
+		exit 1
+	}
+	[[ " ${names[$architecture]:-} " != *" $pkgname "* ]] || {
+		printf 'duplicate %s for %s\n' "$pkgname" "$architecture" >&2
+		exit 1
+	}
+	names[$architecture]="${names[$architecture]:-} $pkgname"
+	architectures[$architecture]="${architectures[$architecture]:-} $package_filename"
+	cp -p "$package" "$staging_directory/$package_filename"
+done
+
+# The core declares a hard dependency on the client, so a repository carrying
+# one without the other cannot install what it publishes.
+for architecture in "${!names[@]}"; do
+	for required in vitasdk-core vdpm; do
+		[[ " ${names[$architecture]} " == *" $required "* ]] || {
+			printf 'no %s for %s: the repository would publish a core that cannot be installed\n' \
+				"$required" "$architecture" >&2
+			exit 1
+		}
+	done
+done
+
+normalize_database() {
+	local source_archive=$1 output_archive=$2 extraction_directory list_file
+	extraction_directory=$(mktemp -d "$temporary_directory/database.XXXXXXXX")
+	list_file=$(mktemp "$temporary_directory/list.XXXXXXXX")
+	bsdtar -xf "$source_archive" -C "$extraction_directory"
+	find "$extraction_directory" -exec touch -h -d "@$source_date_epoch" {} +
+	(
+		cd "$extraction_directory"
+		find . -mindepth 1 -printf '%P\n' | LC_ALL=C sort >"$list_file"
+		bsdtar --format=gnutar --uid 0 --gid 0 --uname root --gname root \
+			-cnf - -T "$list_file" | gzip -9 -n >"$output_archive"
+	)
+}
+
+mapfile -t sorted_architectures < <(printf '%s\n' "${!architectures[@]}" | LC_ALL=C sort)
+for architecture in "${sorted_architectures[@]}"; do
+	read -r -a package_filenames <<<"${architectures[$architecture]}"
+	packages=()
+	for package_filename in "${package_filenames[@]}"; do
+		packages+=("$staging_directory/$package_filename")
+	done
+	repo-add "$staging_directory/$architecture.db.tar.gz" "${packages[@]}"
+	normalize_database "$staging_directory/$architecture.db.tar.gz" \
+		"$temporary_directory/$architecture.db"
+	normalize_database "$staging_directory/$architecture.files.tar.gz" \
+		"$temporary_directory/$architecture.files"
+	rm -f "$staging_directory/$architecture.db" \
+		"$staging_directory/$architecture.db.tar.gz" \
+		"$staging_directory/$architecture.files" \
+		"$staging_directory/$architecture.files.tar.gz"
+	mv "$temporary_directory/$architecture.db" "$staging_directory/$architecture.db"
+	mv "$temporary_directory/$architecture.files" "$staging_directory/$architecture.files"
+done
+
+if [[ -n ${SDK_ARCHIVE_DIRECTORY:-} ]]; then
+	[[ -d $SDK_ARCHIVE_DIRECTORY ]] || {
+		printf 'SDK archive directory not found: %s\n' "$SDK_ARCHIVE_DIRECTORY" >&2
+		exit 1
+	}
+	while IFS= read -r -d '' sdk_archive; do
+		archive_filename=${sdk_archive##*/}
+		[[ ! -e $staging_directory/$archive_filename ]] || {
+			printf 'duplicate SDK archive: %s\n' "$archive_filename" >&2
+			exit 1
+		}
+		cp -p "$sdk_archive" "$staging_directory/$archive_filename"
+	done < <(
+		# vitasdk-sysroot-* is stage 1's internal artifact, not a host SDK.
+		find "$SDK_ARCHIVE_DIRECTORY" -type f \
+			\( -name 'vitasdk-*.tar.bz2' -o -name 'vitasdk-*.tar.bz2.sha256' \) \
+			! -name 'vitasdk-sysroot-*' \
+			-print0 |
+			LC_ALL=C sort -z
+	)
+fi
+
+if [[ -n ${RELEASE_SCHEMA:-}${RELEASE_BUILD_ID:-}${RELEASE_BUILDSCRIPTS_REVISION:-}${RELEASE_PROFILE:-}${RELEASE_PROVENANCE_DIRECTORY:-} ]]; then
+	for var in RELEASE_SCHEMA RELEASE_BUILD_ID RELEASE_BUILDSCRIPTS_REVISION RELEASE_PROFILE RELEASE_PROVENANCE_DIRECTORY; do
+		[[ -n ${!var:-} ]] || {
+			printf '%s must be set alongside the other RELEASE_* variables\n' "$var" >&2
+			exit 1
+		}
+	done
+	[[ -d $RELEASE_PROVENANCE_DIRECTORY ]] || {
+		printf 'release provenance directory not found: %s\n' "$RELEASE_PROVENANCE_DIRECTORY" >&2
+		exit 1
+	}
+	# No python3 assumed: the grouping container does not carry one.
+	json_escape() {
+		local s=$1
+		s=${s//\\/\\\\}
+		s=${s//\"/\\\"}
+		printf '%s' "$s"
+	}
+	json_string_array() {
+		local first=1 item
+		printf '['
+		for item in "$@"; do
+			[[ $first == 1 ]] && first=0 || printf ','
+			printf '"%s"' "$(json_escape "$item")"
+		done
+		printf ']'
+	}
+	# Stage-1 dirs are skipped: a lock may reuse a host name at stage 1 (the
+	# sysroot producer) as well as the stage where it publishes packages.
+	provenance_build_id_for_host() {
+		local target=$1 dir=$2 file file_host
+		for file in "$dir"/*/provenance.json; do
+			[[ -f $file ]] || continue
+			case $file in "$dir"/stage1-*/provenance.json) continue ;; esac
+			file_host=$(sed -n 's/^  "host": "\(.*\)",\{0,1\}$/\1/p' "$file")
+			[[ $file_host == "$target" ]] || continue
+			sed -n 's/^  "build_id": "\(.*\)",\{0,1\}$/\1/p' "$file"
+			return 0
+		done
+		return 1
+	}
+
+	host_fragments=()
+	for architecture in "${sorted_architectures[@]}"; do
+		host_artifacts=("$architecture.db" "$architecture.files")
+		read -r -a package_filenames <<<"${architectures[$architecture]}"
+		host_artifacts+=("${package_filenames[@]}")
+		while IFS= read -r -d '' extra; do
+			host_artifacts+=("$(basename "$extra")")
+		done < <(find "$staging_directory" -maxdepth 1 -type f \
+			\( -name "vitasdk-bootstrap-$architecture.tar.bz2*" -o -name "vitasdk-$architecture-*.tar.bz2*" \) -print0)
+
+		build_id=$(provenance_build_id_for_host "$architecture" "$RELEASE_PROVENANCE_DIRECTORY")
+		[[ -n $build_id ]] || {
+			printf 'no provenance echo found for published host: %s\n' "$architecture" >&2
+			exit 1
+		}
+		host_fragments+=("{\"name\":\"$(json_escape "$architecture")\",\"build_id\":\"$(json_escape "$build_id")\",\"artifacts\":$(json_string_array "${host_artifacts[@]}")}")
+	done
+
+	hosts_joined=$(
+		IFS=,
+		printf '%s' "${host_fragments[*]}"
+	)
+	cat >"$staging_directory/release.json" <<EOF
+{
+  "schema": $RELEASE_SCHEMA,
+  "build_id": "$(json_escape "$RELEASE_BUILD_ID")",
+  "buildscripts_revision": "$(json_escape "$RELEASE_BUILDSCRIPTS_REVISION")",
+  "profile": "$(json_escape "$RELEASE_PROFILE")",
+  "hosts": [$hosts_joined]
+}
+EOF
+fi
+
+(
+	cd "$staging_directory"
+	while IFS= read -r asset; do
+		sha256sum -- "$asset"
+	done < <(
+		find . -maxdepth 1 -type f ! -name SHA256SUMS ! -name release.json -printf '%P\n' |
+			LC_ALL=C sort
+	) >SHA256SUMS
+)
+
+mv "$staging_directory" "$output_directory"
+printf 'created grouped core repositories: %s\n' "$output_directory"

--- a/tests/ci/test-build-host-args.sh
+++ b/tests/ci/test-build-host-args.sh
@@ -74,4 +74,19 @@ grep -q 'needs some-other-host' <<< "$output" || {
 	exit 1
 }
 
+# 4. Flipping packaged on for a musl host fails loudly: that path builds
+# only the SDK tarball and must not publish a quietly incomplete host.
+if output=$(run_build_host \
+	--host x86_64-linux-musl --stage 2 \
+	--artifacts-dir "$temporary_directory/artifacts-4" --out-dir "$temporary_directory/out-4" \
+	--build-id sha256:test --version 0.1.1 --revision "$revision" --profile vita \
+	--packaged true 2>&1); then
+	printf 'build-host.sh accepted a packaged musl host\n' >&2
+	exit 1
+fi
+grep -q 'packaged musl hosts are not implemented' <<< "$output" || {
+	printf 'build-host.sh did not refuse the packaged musl host: %s\n' "$output" >&2
+	exit 1
+}
+
 printf 'build-host.sh argument contract tests passed\n'

--- a/tests/ci/test-build-host-args.sh
+++ b/tests/ci/test-build-host-args.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Argument-contract tests for scripts/ci/build-host.sh: the packaged/build_host
+# wiring that replaced the internal is_required_host list and the per-host
+# build_sdk_host table. Stops short of a real build (needs a full toolchain).
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/buildscripts-build-host-args.XXXXXXXX")
+cleanup() { rm -rf -- "$temporary_directory"; }
+trap cleanup EXIT
+
+# A fake uname keeps install_dependencies() a no-op (neither Darwin nor
+# Linux matches) so this test never touches apt/brew/network. A redirected
+# HOME keeps the script's `git config --global` off the real machine config.
+fake_bin="$temporary_directory/bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/uname" <<'EOF'
+#!/usr/bin/env bash
+echo TestOS
+EOF
+chmod +x "$fake_bin/uname"
+fake_home="$temporary_directory/home"
+mkdir -p "$fake_home"
+
+revision=$(git -C "$repository_root" rev-parse HEAD)
+
+run_build_host() {
+	PATH="$fake_bin:$PATH" HOME="$fake_home" \
+		bash "$repository_root/scripts/ci/build-host.sh" "$@"
+}
+
+# 1. A missing required flag fails fast, naming it.
+if output=$(run_build_host \
+	--host x86_64-linux-gnu --stage 2 \
+	--artifacts-dir "$temporary_directory/artifacts" --out-dir "$temporary_directory/out" \
+	--build-id sha256:test --version 0.1.1 --revision "$revision" --profile vita 2>&1); then
+	printf 'build-host.sh accepted a run with no --packaged\n' >&2
+	exit 1
+fi
+grep -q -- '--packaged is required' <<< "$output" || {
+	printf 'build-host.sh did not name the missing --packaged flag: %s\n' "$output" >&2
+	exit 1
+}
+
+# 2. A packaged stage-3 host with no --build-host fails: the build machine
+# comes from the lock now, not a hardcoded per-host table.
+if output=$(run_build_host \
+	--host x86_64-w64-mingw32 --stage 3 \
+	--artifacts-dir "$temporary_directory/artifacts-2" --out-dir "$temporary_directory/out-2" \
+	--build-id sha256:test --version 0.1.1 --revision "$revision" --profile vita \
+	--packaged true 2>&1); then
+	printf 'build-host.sh accepted a stage-3 host with no --build-host\n' >&2
+	exit 1
+fi
+grep -q 'has no build-machine mapping' <<< "$output" || {
+	printf 'build-host.sh did not name the missing build-machine mapping: %s\n' "$output" >&2
+	exit 1
+}
+
+# 3. A given --build-host is what gets looked up, not an internal default:
+# an artifacts dir with no matching stage2-<build-host> directory fails,
+# naming the exact value passed in.
+if output=$(run_build_host \
+	--host x86_64-w64-mingw32 --stage 3 \
+	--artifacts-dir "$temporary_directory/artifacts-3" --out-dir "$temporary_directory/out-3" \
+	--build-id sha256:test --version 0.1.1 --revision "$revision" --profile vita \
+	--packaged true --build-host some-other-host 2>&1); then
+	printf 'build-host.sh accepted a --build-host with no matching artifact\n' >&2
+	exit 1
+fi
+grep -q 'needs some-other-host' <<< "$output" || {
+	printf 'build-host.sh did not name the requested build-host: %s\n' "$output" >&2
+	exit 1
+}
+
+printf 'build-host.sh argument contract tests passed\n'

--- a/tests/ci/test-create-core-repositories.sh
+++ b/tests/ci/test-create-core-repositories.sh
@@ -13,7 +13,9 @@ pacman_image='archlinux@sha256:c1829f370be8434135f43fb3acaef1256780804ac3b2d2eec
 
 cleanup() {
 	chmod -R u+rwX "$temporary_root" 2>/dev/null || true
-	rm -rf -- "$temporary_root"
+	# On a Linux host the container's root-owned files may defeat this;
+	# leftovers in an ephemeral runner must not override the test verdict.
+	rm -rf -- "$temporary_root" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -53,6 +55,7 @@ docker run --rm \
 	--env RELEASE_BUILDSCRIPTS_REVISION=0123456789abcdef0123456789abcdef01234567 \
 	--env RELEASE_PROFILE=vita \
 	--env RELEASE_PROVENANCE_DIRECTORY=/work/provenance \
+	--env HOST_UID="$(id -u)" --env HOST_GID="$(id -g)" \
 	"$pacman_image" \
 	bash -euc '
 		export LC_ALL=C
@@ -199,6 +202,10 @@ EOF
 			printf "grouping without a full provenance set was unexpectedly accepted\n" >&2
 			exit 1
 		fi
+
+		# Everything under /work was written as root; hand it back to the
+		# host user so the cleanup trap can actually remove it.
+		chown -R "$HOST_UID:$HOST_GID" /work
 	'
 
 printf 'VitaSDK grouped core repository contracts passed\n'

--- a/tests/ci/test-create-core-repositories.sh
+++ b/tests/ci/test-create-core-repositories.sh
@@ -120,11 +120,11 @@ EOF
 			exit 1
 		fi
 
-		# release.json exists, is not covered by SHA256SUMS, and echoes what
-		# each host reported.
+		# release.json exists, is covered by SHA256SUMS like every other
+		# published file, and echoes what each host reported.
 		test -f /work/repository-one/release.json
-		if grep -q release.json /work/repository-one/SHA256SUMS; then
-			printf "release.json must not be covered by SHA256SUMS\n" >&2
+		if ! grep -q release.json /work/repository-one/SHA256SUMS; then
+			printf "release.json must be covered by SHA256SUMS\n" >&2
 			exit 1
 		fi
 		python3 -c "

--- a/tests/ci/test-create-core-repositories.sh
+++ b/tests/ci/test-create-core-repositories.sh
@@ -120,6 +120,22 @@ EOF
 			exit 1
 		fi
 
+		# Each .db has to register the exact set of packages published for
+		# its architecture -- name and version included, straight from a real
+		# pacman database, not the self-reported echo in release.json. A
+		# missing registration or a phantom one (registered but no file on
+		# disk) shows up as a diff line and, with -e active, fails the test.
+		for architecture in x86_64-linux-gnu aarch64-linux-gnu; do
+			find /work -maxdepth 1 -name "*-$architecture.pkg.tar.xz" -printf "%f\n" |
+				LC_ALL=C sort > "/work/actual-packages-$architecture"
+			while IFS= read -r description; do
+				bsdtar -xOf "/work/repository-one/$architecture.db" "$description" |
+					awk "previous == \"%FILENAME%\" { print; exit } { previous = \$0 }"
+			done < <(bsdtar -tf "/work/repository-one/$architecture.db" | grep "/desc\$") |
+				LC_ALL=C sort > "/work/database-packages-$architecture"
+			diff -u "/work/actual-packages-$architecture" "/work/database-packages-$architecture"
+		done
+
 		# release.json exists, is covered by SHA256SUMS like every other
 		# published file, and echoes what each host reported.
 		test -f /work/repository-one/release.json

--- a/tests/ci/test-create-core-repositories.sh
+++ b/tests/ci/test-create-core-repositories.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Contract test for scripts/create-core-repositories.sh: the grouped
+# repository behavior ported from vitasdk/autobuilds (reproducibility,
+# client-dependency enforcement, corruption detection) plus this workflow's
+# addition, release.json -- shape owned by `verify` (next-refactor-verify),
+# produced here.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/vitasdk-buildscripts-repository.XXXXXXXX")
+pacman_image='archlinux@sha256:c1829f370be8434135f43fb3acaef1256780804ac3b2d2eec90dfb1232e1ffdf'
+
+cleanup() {
+	chmod -R u+rwX "$temporary_root" 2>/dev/null || true
+	rm -rf -- "$temporary_root"
+}
+trap cleanup EXIT
+
+# Provenance echoes: written the same way scripts/ci/lib.sh's
+# ci_write_provenance writes them, into artifact-style stage<N>-<host>
+# directories, since create-core-repositories.sh parses that exact layout
+# without a JSON library (the grouping job runs inside a bare archlinux
+# container that carries no python3).
+write_provenance() {
+	local dir=$1 host=$2 build_id=$3
+	shift 3
+	mkdir -p "$dir"
+	python3 - "$dir/provenance.json" "$host" "$build_id" "$@" <<'PY'
+import json, sys
+out, host, build_id, *artifacts = sys.argv[1:]
+json.dump({"host": host, "build_id": build_id, "artifacts": artifacts}, open(out, "w"), indent=2, sort_keys=True)
+PY
+}
+write_provenance "$temporary_root/provenance/stage2-x86_64-linux-gnu" \
+	x86_64-linux-gnu 'sha256:deadbeef' vitasdk-core-0.1-1-x86_64-linux-gnu.pkg.tar.xz
+write_provenance "$temporary_root/provenance/stage2-aarch64-linux-gnu" \
+	aarch64-linux-gnu 'sha256:deadbeef' vitasdk-core-0.1-1-aarch64-linux-gnu.pkg.tar.xz
+# A decoy: x86_64-linux-gnu also has a stage-1 (sysroot-only) provenance
+# echo with a *different* build_id. If the stage-1 exclusion in
+# provenance_build_id_for_host regresses, this makes the test catch it by
+# tripping the release.json build_id assertion below.
+write_provenance "$temporary_root/provenance/stage1-x86_64-linux-gnu" \
+	x86_64-linux-gnu 'sha256:stage1-decoy' vitasdk-sysroot-fixture.tar.bz2
+
+docker run --rm \
+	--platform linux/amd64 \
+	--mount "type=bind,source=$repository_root,target=/workspace,readonly" \
+	--mount "type=bind,source=$temporary_root,target=/work" \
+	--env SOURCE_DATE_EPOCH=1700000000 \
+	--env RELEASE_SCHEMA=1 \
+	--env RELEASE_BUILD_ID=sha256:deadbeef \
+	--env RELEASE_BUILDSCRIPTS_REVISION=0123456789abcdef0123456789abcdef01234567 \
+	--env RELEASE_PROFILE=vita \
+	--env RELEASE_PROVENANCE_DIRECTORY=/work/provenance \
+	"$pacman_image" \
+	bash -euc '
+		export LC_ALL=C
+		create_package() {
+			local architecture=$1 name=$2 depends=$3 payload=$4
+			local root="/work/package-$name-$architecture"
+			local output="/work/$name-0.1-1-$architecture.pkg.tar.xz"
+			install -d "$root/bin"
+			printf "#!/bin/sh\nexit 0\n" > "$root/bin/$payload"
+			chmod +x "$root/bin/$payload"
+			cat > "$root/.PKGINFO" <<EOF
+pkgname = $name
+pkgbase = $name
+pkgver = 0.1-1
+pkgdesc = VitaSDK core repository fixture
+url = https://vitasdk.org/
+builddate = 1700000000
+packager = VitaSDK Tests
+size = 32
+arch = $architecture
+license = custom
+xdata = pkgtype=pkg
+EOF
+			[ -z "$depends" ] || printf "depend = %s\n" "$depends" >> "$root/.PKGINFO"
+			printf "format = 2\n" > "$root/.BUILDINFO"
+			(
+				cd "$root"
+				find . -mindepth 1 ! -name .MTREE -print0 | sort -z |
+					bsdtar -cnf - --format=mtree \
+						--options="!all,use-set,type,uid,gid,mode,time,size,sha256,link" \
+						--uid 0 --gid 0 --null -T - | gzip -n > .MTREE
+				find . -exec touch -h -d @1700000000 {} +
+				find . -mindepth 1 -printf "%P\n" | sort |
+					bsdtar --format=gnutar --uid 0 --gid 0 \
+						--uname root --gname root -cnf - -T - | xz -9 -c > "$output"
+			)
+		}
+
+		for architecture in x86_64-linux-gnu aarch64-linux-gnu; do
+			create_package "$architecture" vdpm "" vdpm
+			create_package "$architecture" vitasdk-core "vdpm>=0.1-1" \
+				arm-vita-eabi-gcc
+		done
+		mkdir /work/sdk-archives
+		printf "bootstrap fixture\n" > \
+			/work/sdk-archives/vitasdk-bootstrap-x86_64-linux-gnu.tar.bz2
+		printf "bootstrap fixture\n" > \
+			/work/sdk-archives/vitasdk-bootstrap-aarch64-linux-gnu.tar.bz2
+		printf "compatibility fixture\n" > \
+			/work/sdk-archives/vitasdk-x86_64-linux-gnu-fixture.tar.bz2
+		# The tarball stage 1 produces must never reach the published tree:
+		# it is not a host SDK, just an internal artifact of that stage
+		printf "sysroot fixture\n" > \
+			/work/sdk-archives/vitasdk-sysroot-20260822_000000.tar.bz2
+		packages=(/work/*-0.1-1-*.pkg.tar.xz)
+		export SDK_ARCHIVE_DIRECTORY=/work/sdk-archives
+		/workspace/scripts/create-core-repositories.sh \
+			/work/repository-one "${packages[@]}"
+		/workspace/scripts/create-core-repositories.sh \
+			/work/repository-two "${packages[@]}"
+		diff -ru /work/repository-one /work/repository-two
+		test -f /work/repository-one/vitasdk-bootstrap-x86_64-linux-gnu.tar.bz2
+		if [ -e /work/repository-one/vitasdk-sysroot-20260822_000000.tar.bz2 ]; then
+			printf "the stage-1 sysroot tarball leaked into the published tree\n" >&2
+			exit 1
+		fi
+
+		# release.json exists, is not covered by SHA256SUMS, and echoes what
+		# each host reported.
+		test -f /work/repository-one/release.json
+		if grep -q release.json /work/repository-one/SHA256SUMS; then
+			printf "release.json must not be covered by SHA256SUMS\n" >&2
+			exit 1
+		fi
+		python3 -c "
+import json
+manifest = json.load(open(\"/work/repository-one/release.json\"))
+assert manifest[\"schema\"] == 1, manifest
+assert manifest[\"build_id\"] == \"sha256:deadbeef\", manifest
+assert manifest[\"buildscripts_revision\"] == \"0123456789abcdef0123456789abcdef01234567\", manifest
+assert manifest[\"profile\"] == \"vita\", manifest
+hosts = {h[\"name\"]: h for h in manifest[\"hosts\"]}
+assert set(hosts) == {\"x86_64-linux-gnu\", \"aarch64-linux-gnu\"}, hosts
+for name, host in hosts.items():
+    assert host[\"build_id\"] == \"sha256:deadbeef\", host
+    assert f\"{name}.db\" in host[\"artifacts\"], host
+    assert f\"vitasdk-bootstrap-{name}.tar.bz2\" in host[\"artifacts\"], host
+    assert any(a.startswith(\"vitasdk-core-\") for a in host[\"artifacts\"]), host
+print(\"release.json contract passed\")
+"
+
+		cat > /work/pacman.conf <<EOF
+[options]
+Architecture = x86_64-linux-gnu vita
+SigLevel = Never
+[x86_64-linux-gnu]
+Server = file:///work/repository-one
+EOF
+		install -d /sdk/var/lib/pacman /sdk/var/cache/pacman/pkg
+		pacman --config /work/pacman.conf --root /sdk \
+			--dbpath /sdk/var/lib/pacman --cachedir /sdk/var/cache/pacman/pkg \
+			--logfile /sdk/var/log/pacman.log --noscriptlet \
+			--sync --refresh --refresh --noconfirm
+		pacman --config /work/pacman.conf --root /sdk \
+			--dbpath /sdk/var/lib/pacman --cachedir /sdk/var/cache/pacman/pkg \
+			--logfile /sdk/var/log/pacman.log --noscriptlet \
+			--sync --noconfirm vitasdk-core
+		test -x /sdk/bin/arm-vita-eabi-gcc
+		test -x /sdk/bin/vdpm
+		pacman --config /work/pacman.conf --root /sdk \
+			--dbpath /sdk/var/lib/pacman --query vdpm
+
+		core_only=(/work/vitasdk-core-0.1-1-*.pkg.tar.xz)
+		if /workspace/scripts/create-core-repositories.sh \
+			/work/repository-without-client "${core_only[@]}" 2>/dev/null; then
+			printf "a repository without the client was unexpectedly built\n" >&2
+			exit 1
+		fi
+
+		# A published architecture with no provenance echo is a grouping bug,
+		# not a build_id mismatch (verify checks that); catch it here.
+		rm -rf /work/provenance-partial
+		mkdir -p /work/provenance-partial
+		cp -a /work/provenance/stage2-x86_64-linux-gnu /work/provenance-partial/
+		if RELEASE_PROVENANCE_DIRECTORY=/work/provenance-partial \
+			/workspace/scripts/create-core-repositories.sh \
+			/work/repository-missing-provenance "${packages[@]}" 2>/dev/null; then
+			printf "grouping without a full provenance set was unexpectedly accepted\n" >&2
+			exit 1
+		fi
+	'
+
+printf 'VitaSDK grouped core repository contracts passed\n'

--- a/tests/ci/test-parse-lock.sh
+++ b/tests/ci/test-parse-lock.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Contract tests for the reusable build workflow's schema gate
+# (scripts/ci/parse-lock.py): the one piece of the shell that inspects the
+# lock at all, so it is the one piece worth unit-testing directly.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+temporary_directory=$(mktemp -d "${TMPDIR:-/tmp}/buildscripts-parse-lock.XXXXXXXX")
+cleanup() { rm -rf -- "$temporary_directory"; }
+trap cleanup EXIT
+
+run_parse() {
+	local lock_json=$1 output_file="$temporary_directory/output-$RANDOM"
+	: >"$output_file"
+	LOCK_JSON=$lock_json GITHUB_OUTPUT="$output_file" \
+		python3 "$repository_root/scripts/ci/parse-lock.py"
+	printf '%s\n' "$output_file"
+}
+
+assert_fails() {
+	local lock_json=$1 message=$2 output_file="$temporary_directory/output-$RANDOM"
+	: >"$output_file"
+	if LOCK_JSON=$lock_json GITHUB_OUTPUT="$output_file" \
+		python3 "$repository_root/scripts/ci/parse-lock.py" 2>/dev/null; then
+		printf '%s: unexpectedly succeeded\n' "$message" >&2
+		exit 1
+	fi
+}
+
+output_value() {
+	local output_file=$1 name=$2
+	awk -v name="$name" '
+		!in_block && index($0, name "<<") == 1 {
+			delim = substr($0, length(name) + 3)
+			in_block = 1
+			next
+		}
+		in_block && $0 == delim { in_block = 0; next }
+		in_block { print }
+	' "$output_file"
+}
+
+# x86_64-linux-gnu deliberately recurs at stage 1 (sysroot producer) and
+# stage 2 (native SDK) -- matching the real describe hosts.json shape, not
+# an invented pseudo-host name for stage 1.
+good_lock='{
+  "schema": 1,
+  "build_id": "sha256:aaaa",
+  "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567",
+  "profile": "vita",
+  "version": "0.20260822.249",
+  "hosts": [
+    {"name": "x86_64-linux-gnu", "stage": 1, "runner": "ubuntu-24.04", "container": "ubuntu:20.04"},
+    {"name": "x86_64-linux-gnu", "stage": 2, "runner": "ubuntu-24.04", "container": "ubuntu:20.04"},
+    {"name": "x86_64-w64-mingw32", "stage": 3, "runner": "ubuntu-24.04", "container": null}
+  ]
+}'
+
+# 1. A well-formed schema-1 lock is accepted and grouped by stage, and the
+# same host name recurring at two stages is not treated as a duplicate.
+output=$(run_parse "$good_lock")
+[[ $(output_value "$output" schema) == 1 ]]
+[[ $(output_value "$output" build_id) == 'sha256:aaaa' ]]
+[[ $(output_value "$output" version) == '0.20260822.249' ]]
+stage1=$(output_value "$output" stage1_hosts)
+stage2=$(output_value "$output" stage2_hosts)
+stage3=$(output_value "$output" stage3_hosts)
+python3 -c "
+import json, sys
+stage1, stage2, stage3 = json.loads(sys.argv[1]), json.loads(sys.argv[2]), json.loads(sys.argv[3])
+assert [h['name'] for h in stage1] == ['x86_64-linux-gnu'], stage1
+assert [h['name'] for h in stage2] == ['x86_64-linux-gnu'], stage2
+assert [h['name'] for h in stage3] == ['x86_64-w64-mingw32'], stage3
+assert stage3[0]['container'] == '', stage3[0]
+" "$stage1" "$stage2" "$stage3"
+
+# 2. An unsupported schema fails loudly and does not silently misbuild.
+assert_fails '{"schema": 2, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}]}' \
+	"schema 2 against a schema-1 shell"
+
+# 3. Malformed JSON fails.
+assert_fails 'not json' "malformed JSON"
+
+# 4. A missing required field fails.
+assert_fails '{"schema": 1, "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}]}' \
+	"missing build_id"
+
+# 5. A non-40-hex revision fails.
+assert_fails '{"schema": 1, "build_id": "x", "buildscripts_revision": "short", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}]}' \
+	"short revision"
+
+# 6. Empty hosts[] fails.
+assert_fails '{"schema": 1, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": []}' \
+	"empty hosts"
+
+# 7. A host declaring a stage outside {1,2,3} under schema 1 fails.
+assert_fails '{"schema": 1, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 4, "runner": "r"}]}' \
+	"stage 4 under schema 1"
+
+# 8. A duplicate (name, stage) pair fails; the same name at two different
+# stages does not (see the good_lock fixture above).
+assert_fails '{"schema": 1, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}, {"name": "a", "stage": 1, "runner": "r"}]}' \
+	"duplicate (name, stage) pair"
+
+# 9. A stage with no hosts groups to an empty JSON array, the shell's signal
+# to skip that stage job without failing.
+output=$(run_parse '{"schema": 1, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}]}')
+[[ $(output_value "$output" stage2_hosts) == '[]' ]]
+[[ $(output_value "$output" stage3_hosts) == '[]' ]]
+
+printf 'parse-lock.py contract tests passed\n'

--- a/tests/ci/test-parse-lock.sh
+++ b/tests/ci/test-parse-lock.sh
@@ -51,9 +51,9 @@ good_lock='{
   "profile": "vita",
   "version": "0.20260822.249",
   "hosts": [
-    {"name": "x86_64-linux-gnu", "stage": 1, "runner": "ubuntu-24.04", "container": "ubuntu:20.04"},
-    {"name": "x86_64-linux-gnu", "stage": 2, "runner": "ubuntu-24.04", "container": "ubuntu:20.04"},
-    {"name": "x86_64-w64-mingw32", "stage": 3, "runner": "ubuntu-24.04", "container": null}
+    {"name": "x86_64-linux-gnu", "stage": 1, "runner": "ubuntu-24.04", "container": "ubuntu:20.04", "packaged": false},
+    {"name": "x86_64-linux-gnu", "stage": 2, "runner": "ubuntu-24.04", "container": "ubuntu:20.04", "packaged": true},
+    {"name": "x86_64-w64-mingw32", "stage": 3, "runner": "ubuntu-24.04", "container": null, "packaged": true, "build_host": "x86_64-linux-gnu"}
   ]
 }'
 
@@ -73,7 +73,26 @@ assert [h['name'] for h in stage1] == ['x86_64-linux-gnu'], stage1
 assert [h['name'] for h in stage2] == ['x86_64-linux-gnu'], stage2
 assert [h['name'] for h in stage3] == ['x86_64-w64-mingw32'], stage3
 assert stage3[0]['container'] == '', stage3[0]
+# packaged and build_host propagate to matrix entries: false/'' unless the
+# lock's host entry says otherwise.
+assert stage1[0]['packaged'] is False, stage1[0]
+assert stage1[0]['build_host'] == '', stage1[0]
+assert stage2[0]['packaged'] is True, stage2[0]
+assert stage2[0]['build_host'] == '', stage2[0]
+assert stage3[0]['packaged'] is True, stage3[0]
+assert stage3[0]['build_host'] == 'x86_64-linux-gnu', stage3[0]
 " "$stage1" "$stage2" "$stage3"
+
+# 1b. A host entry predating the packaged/build_host fields still parses,
+# defaulting to unpackaged with no build machine.
+legacy_output=$(run_parse '{"schema": 1, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}]}')
+legacy_stage1=$(output_value "$legacy_output" stage1_hosts)
+python3 -c "
+import json, sys
+host = json.loads(sys.argv[1])[0]
+assert host['packaged'] is False, host
+assert host['build_host'] == '', host
+" "$legacy_stage1"
 
 # 2. An unsupported schema fails loudly and does not silently misbuild.
 assert_fails '{"schema": 2, "build_id": "x", "buildscripts_revision": "0123456789abcdef0123456789abcdef01234567", "profile": "vita", "version": "1", "hosts": [{"name": "a", "stage": 1, "runner": "r"}]}' \

--- a/tests/ci/test-smoke-windows-bootstrap.sh
+++ b/tests/ci/test-smoke-windows-bootstrap.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/ci/smoke-windows-bootstrap.ps1's local decision
+# logic (no-op vs. fail) -- the parts reachable without a real Windows
+# runner or a real bootstrap archive.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+script="$repository_root/scripts/ci/smoke-windows-bootstrap.ps1"
+command -v pwsh >/dev/null || {
+	printf 'pwsh is required to run this test\n' >&2
+	exit 1
+}
+
+temporary_root=$(mktemp -d "${TMPDIR:-/tmp}/vitasdk-smoke-windows-bootstrap.XXXXXXXX")
+cleanup() { rm -rf -- "$temporary_root"; }
+trap cleanup EXIT
+
+host=x86_64-w64-mingw32
+
+# 1. No artifacts directory at all: clean no-op.
+if ! output=$(pwsh -NoProfile -File "$script" -ArtifactsDir "$temporary_root/missing" 2>&1); then
+	printf 'expected a clean no-op for a missing artifacts directory, got:\n%s\n' "$output" >&2
+	exit 1
+fi
+grep -q 'nothing to smoke test' <<<"$output" || {
+	printf 'expected a "nothing to smoke test" message, got:\n%s\n' "$output" >&2
+	exit 1
+}
+
+# 2. An artifacts directory with no matching archive: clean no-op.
+empty_dir="$temporary_root/empty"
+mkdir -p "$empty_dir"
+if ! output=$(pwsh -NoProfile -File "$script" -ArtifactsDir "$empty_dir" 2>&1); then
+	printf 'expected a clean no-op for an empty artifacts directory, got:\n%s\n' "$output" >&2
+	exit 1
+fi
+grep -q 'nothing to smoke test' <<<"$output" || {
+	printf 'expected a "nothing to smoke test" message, got:\n%s\n' "$output" >&2
+	exit 1
+}
+
+# 3. An archive with no checksum sidecar fails loudly instead of skipping it.
+no_checksum_dir="$temporary_root/no-checksum/stage3-$host"
+mkdir -p "$no_checksum_dir"
+printf 'fixture\n' >"$no_checksum_dir/vitasdk-bootstrap-$host.tar.bz2"
+if pwsh -NoProfile -File "$script" -ArtifactsDir "$temporary_root/no-checksum" >/dev/null 2>&1; then
+	printf 'expected failure for an archive with no checksum sidecar\n' >&2
+	exit 1
+fi
+
+# 4. Two artifact directories both claiming the Windows archive: ambiguous,
+# must fail rather than silently picking one.
+duplicate_root="$temporary_root/duplicate"
+mkdir -p "$duplicate_root/stage3-$host" "$duplicate_root/stage3-other"
+printf 'fixture\n' >"$duplicate_root/stage3-$host/vitasdk-bootstrap-$host.tar.bz2"
+printf 'fixture\n' >"$duplicate_root/stage3-$host/vitasdk-bootstrap-$host.tar.bz2.sha256"
+printf 'fixture\n' >"$duplicate_root/stage3-other/vitasdk-bootstrap-$host.tar.bz2"
+if pwsh -NoProfile -File "$script" -ArtifactsDir "$duplicate_root" >/dev/null 2>&1; then
+	printf 'expected failure for two artifact directories claiming the Windows archive\n' >&2
+	exit 1
+fi
+
+printf 'smoke-windows-bootstrap.ps1 contract tests passed\n'


### PR DESCRIPTION
Phase 2 of the refactor: the reusable staged build workflow (`workflow_call` + `workflow_dispatch`), pure addition — the existing `build.yml` is untouched and nothing consumes this yet.

`build-sdk.yml` is a generic staged executor with zero VitaSDK knowledge in the YAML: a `gate` job validates the lock (schema, `build_id`, revision, version) and emits per-stage matrices with `fromJSON`; each stage job checks out this repo at the lock's revision and hands the `(stage, host)` pair to `scripts/ci/build-host.sh`, which owns the actual build knowledge — stage-1 target-only, native stage 2 (musl inside Alpine), canadian stage 3 importing the build machine's full stage-2 SDK (`build_host` comes from the lock, not a hardcoded table). Packaged hosts get the full treatment: vdpm bundle download verified against its sidecar, `core-package` + `bootstrap-archive`, a same-runner bootstrap smoke test, and a hard assertion that every artifact family was actually produced (a packaged host cannot publish quietly incomplete). A fixed non-matrixed job exercises the Windows bootstrap on a real `windows-2025` runner, no-oping from inside the script when the lock builds no Windows.

The grouping job ports `create-core-repositories.sh` from autobuilds and extends it to emit `release.json` + `SHA256SUMS` in exactly the shape `verify` validates, with per-host `build_id` echoes read from each job's provenance. Its test suite runs real `repo-add`/`bsdtar`/pacman inside an archlinux container, including registering-vs-present database cross-checks and an install exercise.

Everything is inert until exercised: the plan is a `workflow_dispatch` run with a real `describe` lock right after this merges, before anything depends on it.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).
