### PR TITLE
Survive download-artifact extracting a single pattern match flat

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -246,17 +246,12 @@ jobs:
           repository: ${{ env.BUILDSCRIPTS_REPO }}
           ref: ${{ needs.gate.outputs.buildscripts_revision }}
           fetch-depth: 0
+      # One pattern-less download: single pattern matches extract flat, and
+      # two flat extractions into one directory overwrite each other's
+      # provenance.json. Every artifact of this run is a stage artifact, and
+      # more than one always exists, so this always nests per artifact name.
       - uses: actions/download-artifact@v7
         with:
-          pattern: stage1-*
-          path: artifacts
-      - uses: actions/download-artifact@v7
-        with:
-          pattern: stage2-*
-          path: artifacts
-      - uses: actions/download-artifact@v7
-        with:
-          pattern: stage3-*
           path: artifacts
       - name: Group the release tree
         shell: bash

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -50,6 +50,21 @@ ci_find_stage_artifact() {
 	for candidate in "$artifacts_dir"/stage"$stage"-$name_glob; do
 		[[ -d $candidate ]] && printf '%s\n' "$candidate" && return 0
 	done
+	# download-artifact extracts a single pattern match flat, without the
+	# artifact's directory; the provenance still names the host, and the
+	# caller's download pattern already fixed the stage.
+	if [[ -f $artifacts_dir/provenance.json ]]; then
+		if [[ $name_glob == '*' ]]; then
+			printf '%s\n' "$artifacts_dir"
+			return 0
+		fi
+		local host
+		host=$(sed -n 's/^  "host": "\(.*\)",\{0,1\}$/\1/p' "$artifacts_dir/provenance.json")
+		if [[ $host == "$name_glob" ]]; then
+			printf '%s\n' "$artifacts_dir"
+			return 0
+		fi
+	fi
 	return 1
 }
 

--- a/tests/ci/test-build-host-args.sh
+++ b/tests/ci/test-build-host-args.sh
@@ -74,7 +74,30 @@ grep -q 'needs some-other-host' <<< "$output" || {
 	exit 1
 }
 
-# 4. Flipping packaged on for a musl host fails loudly: that path builds
+# 4. A flat artifacts dir (a single pattern match extracts without the
+# artifact's directory) is accepted by the stage-1 lookup: the run must get
+# past "stage1 artifact not found" and fail later, at the unpack step.
+flat_dir="$temporary_directory/artifacts-flat"
+mkdir -p "$flat_dir"
+printf '{\n  "host": "someone",\n  "build_id": "sha256:test"\n}\n' > "$flat_dir/provenance.json"
+if output=$(run_build_host \
+	--host x86_64-linux-gnu --stage 2 \
+	--artifacts-dir "$flat_dir" --out-dir "$temporary_directory/out-flat" \
+	--build-id sha256:test --version 0.1.1 --revision "$revision" --profile vita \
+	--packaged false 2>&1); then
+	printf 'build-host.sh unexpectedly succeeded on a flat artifacts dir\n' >&2
+	exit 1
+fi
+if grep -q 'stage1 artifact not found' <<< "$output"; then
+	printf 'the flat artifacts layout was not accepted by the stage-1 lookup: %s\n' "$output" >&2
+	exit 1
+fi
+grep -q 'no .tar.bz2 archive found' <<< "$output" || {
+	printf 'expected the failure to move on to the unpack step: %s\n' "$output" >&2
+	exit 1
+}
+
+# 5. Flipping packaged on for a musl host fails loudly: that path builds
 # only the SDK tarball and must not publish a quietly incomplete host.
 if output=$(run_build_host \
 	--host x86_64-linux-musl --stage 2 \


### PR DESCRIPTION
The maiden workflow_dispatch of build-sdk.yml (run 32728807501) failed in every stage-2 leg: `actions/download-artifact` with a `pattern` matching exactly one artifact extracts it flat into `path`, without the artifact's named directory, so the stage-1 lookup found no `stage1-*` directory. The same behavior would have bitten the grouping job worse — its stage1 and stage3 patterns each match one artifact, and two flat extractions into one directory overwrite each other's `provenance.json`.

Two changes: the stage lookup in `scripts/ci/lib.sh` accepts a flat layout, verifying the host against the provenance echo when the caller asks for a specific one; and the grouping job replaces its three pattern downloads with one pattern-less download of the run's artifacts, which always nests (a run always carries more than one). The smoke-windows job already handled both layouts (`-Recurse`) — its no-op path passed on the failed run, as designed. Contract test added for the flat lookup.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).