### PR TITLE
Install libarchive-tools where the packaging runs

### DIFF
--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -242,6 +242,7 @@ install_dependencies() {
 		"${sudo_cmd[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
 			cmake cmake-data git build-essential autoconf automake libtool \
 			texinfo bison flex pkg-config python3 python3-pip curl bzip2 xz-utils \
+			libarchive-tools \
 			"${extra[@]}"
 		pip3 install --quiet cmake==3.31.6
 		;;


### PR DESCRIPTION
Third finding from the maiden runs of build-sdk.yml, and the deepest yet: the aarch64 stage-2 leg built the whole SDK, passed the toolchain contract and the dependency audit, and died creating the first package — `bsdtar: command not found`. `create-core-package.sh` drives bsdtar; the autobuilds job that used to run this packaging installed `libarchive-tools`, and the dependency did not travel when the packaging moved into the reusable workflow. One word in the executor's apt list. macOS ships bsdtar and needed nothing.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).