### PR TITLE
Cache compilation across candidates

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -27,6 +27,12 @@ on:
 
 env:
   BUILDSCRIPTS_REPO: vitasdk/buildscripts
+  # Under the workspace on purpose: the musl leg builds inside a container
+  # that already bind-mounts it, so one setting serves both.
+  CCACHE_DIR: ${{ github.workspace }}/.ccache
+  CCACHE_MAXSIZE: 2G
+  CCACHE_COMPRESS: "1"
+  CCACHE_COMPRESSLEVEL: "6"
 
 jobs:
   # Checks out the calling ref's own parser, never the lock's revision.
@@ -78,6 +84,11 @@ jobs:
           repository: ${{ env.BUILDSCRIPTS_REPO }}
           ref: ${{ needs.gate.outputs.buildscripts_revision }}
           fetch-depth: 0
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: stage${{ matrix.stage }}-${{ matrix.name }}-ccache-${{ needs.gate.outputs.buildscripts_revision }}
+          restore-keys: stage${{ matrix.stage }}-${{ matrix.name }}-ccache-
       - name: Build stage 1 host ${{ matrix.name }}
         shell: bash
         run: |
@@ -129,6 +140,11 @@ jobs:
         with:
           pattern: stage1-*
           path: artifacts
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: stage${{ matrix.stage }}-${{ matrix.name }}-ccache-${{ needs.gate.outputs.buildscripts_revision }}
+          restore-keys: stage${{ matrix.stage }}-${{ matrix.name }}-ccache-
       - name: Build stage 2 host ${{ matrix.name }}
         shell: bash
         run: |
@@ -180,6 +196,11 @@ jobs:
         with:
           pattern: stage2-*
           path: artifacts
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: stage${{ matrix.stage }}-${{ matrix.name }}-ccache-${{ needs.gate.outputs.buildscripts_revision }}
+          restore-keys: stage${{ matrix.stage }}-${{ matrix.name }}-ccache-
       - name: Build stage 3 host ${{ matrix.name }}
         shell: bash
         run: |

--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -155,6 +155,7 @@ build_and_stage() {
 
 	cmake "${cmake_args[@]}"
 	cmake --build build --target "${targets[@]}" --parallel "$(ci_nproc)"
+	report_ccache_statistics
 
 	# Only a native build can run its own output.
 	if [[ -z $build_host ]]; then
@@ -192,14 +193,19 @@ build_and_stage() {
 
 # musl hosts are native builds inside Alpine (see build.yml stage2-musl).
 build_musl_host() {
+	# CCACHE_DIR lives under the workspace, which is already the bind mount,
+	# so the container reaches the same cache the runner restored.
 	docker run --rm \
 		-v "$PWD":/src -w /src \
 		-e VITASDK_SOURCE_REVISION="$revision" \
 		-e VITASDK_SOURCE_DATE_EPOCH="$source_date_epoch" \
+		-e CCACHE_DIR=/src/.ccache \
+		-e CCACHE_MAXSIZE -e CCACHE_COMPRESS -e CCACHE_COMPRESSLEVEL \
 		alpine:3.20 sh -eux -c '
 			apk add --no-cache bash build-base cmake git autoconf automake \
 				libtool texinfo bison flex pkgconf curl xz python3 bzip2 \
-				tar linux-headers
+				tar linux-headers ccache
+			export PATH="/usr/lib/ccache/bin:$PATH"
 			git config --global --add safe.directory "*"
 			git config --global user.email "builds@ci.invalid"
 			git config --global user.name "buildscripts CI"
@@ -212,6 +218,7 @@ build_musl_host() {
 				-DVITASDK_SOURCE_DATE_EPOCH="$VITASDK_SOURCE_DATE_EPOCH"
 			make -j"$(getconf _NPROCESSORS_ONLN)" tarball
 			make check-toolchain-contract
+			ccache --show-stats || true
 		'
 	local -a produced=(build/vitasdk-*.tar.bz2)
 	local -a names=()
@@ -229,7 +236,7 @@ install_dependencies() {
 	[[ $(id -u) == 0 ]] || sudo_cmd=(sudo)
 	case "$(uname -s)" in
 	Darwin)
-		brew install autoconf automake libtool texinfo
+		brew install autoconf automake libtool texinfo ccache
 		;;
 	Linux)
 		local -a extra=()
@@ -242,22 +249,48 @@ install_dependencies() {
 		"${sudo_cmd[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
 			cmake cmake-data git build-essential autoconf automake libtool \
 			texinfo bison flex pkg-config python3 python3-pip curl bzip2 xz-utils \
-			libarchive-tools \
+			libarchive-tools ccache \
 			"${extra[@]}"
 		pip3 install --quiet cmake==3.31.6
 		;;
 	esac
 }
 
+# gcc, binutils, gdb and newlib are autotools: they honour no CMake variable,
+# and a shim directory in PATH is the only way they pick ccache up.
+enable_ccache() {
+	local shims sudo_cmd=()
+	[[ $(id -u) == 0 ]] || sudo_cmd=(sudo)
+	if [[ $(uname -s) == Darwin ]]; then
+		shims="$(brew --prefix ccache)/libexec"
+	else
+		[[ -x /usr/sbin/update-ccache-symlinks ]] &&
+			"${sudo_cmd[@]}" /usr/sbin/update-ccache-symlinks
+		shims=/usr/lib/ccache
+	fi
+	[[ -d $shims ]] || {
+		printf 'no ccache shim directory at %s; building without it\n' "$shims" >&2
+		return 0
+	}
+	export PATH="$shims:$PATH"
+	ccache --zero-stats >/dev/null 2>&1 || true
+}
+
+report_ccache_statistics() {
+	command -v ccache >/dev/null 2>&1 && ccache --show-stats || true
+}
+
 if [[ $stage == 1 ]]; then
 	# Dispatch is on stage, not host name: the lock may reuse a name here
 	# (e.g. x86_64-linux-gnu) that also appears at stage 2.
 	install_dependencies
+	enable_ccache
 	cmake -S "$repo_root" -B build \
 		-DVITASDK_TARGET_ONLY=ON \
 		-DVITASDK_SOURCE_REVISION="$revision" \
 		-DVITASDK_SOURCE_DATE_EPOCH="$source_date_epoch"
 	cmake --build build --target sysroot --parallel "$(ci_nproc)"
+	report_ccache_statistics
 	cp build/vitasdk-sysroot-*.tar.bz2 "$out_dir/"
 	ci_write_provenance "$out_dir" "$host" "$build_id" "$(basename build/vitasdk-sysroot-*.tar.bz2)"
 	exit 0
@@ -316,6 +349,10 @@ x86_64-apple-darwin)
 	exit 1
 	;;
 esac
+
+# After the case block: every branch of it has installed ccache by now, and
+# the shims must precede the cross toolchains those branches put on PATH.
+enable_ccache
 
 if [[ $stage == 2 ]]; then
 	# Whichever host name produced stage 1 -- see the dispatch note above.


### PR DESCRIPTION
The reusable workflow shipped without ccache — the old `build.yml` mentions it 28 times, `build-sdk.yml` zero — so every candidate paid a full cold build.

The maiden runs hid this, because they compared cold against cold: the staged partition (target code compiled once, each host building only its own half) is what made those times respectable, not caching. Measured on the two comparable runs — same staged topology, one with the ccache plumbing and one without — the per-stage times sat within a couple of minutes of each other, and the run *with* ccache reported `Cache not found for input keys` and a 17% hit rate. Neither run measured the case that matters.

That case is the steady state this refactor is built around: the pin-bump bot produces a candidate where one source pin of thirty-eight moved, and without a cache the other thirty-seven are rebuilt from scratch every night.

Three details worth noting in review:
- `CCACHE_DIR` sits under the workspace rather than `$HOME`. The musl leg builds inside a container that already bind-mounts the workspace, so one setting serves the runner and the container instead of two, with no extra mount.
- The shim directory goes on `PATH` inside `build-host.sh`, not in the YAML: which directory holds the shims is per-platform knowledge, and the shell stays generic. Its placement after the per-host `case` matches the effective ordering `build.yml` has in production (shims ahead of the cross toolchains).
- Each `(stage, host)` gets its own key, stamped with the lock's revision, falling back by prefix to the newest entry for that pair — so a fresh candidate restores the previous one's cache instead of starting empty.

Both legs now report `ccache --show-stats` after building, which is how the 17% above was diagnosed in the first place.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).