### PR TITLE
Embed a vdpm whose installer works

### DIFF
--- a/cmake/Components.cmake
+++ b/cmake/Components.cmake
@@ -74,5 +74,5 @@ set(SAMPLES_TAG fe8fbef570f3280586c0c20157146e3faefb2181 CACHE STRING "samples b
 set(HEADERS_TAG 4f9b5d712751afef804a44d1d248ab2b358cff4a CACHE STRING "vita-headers branch, commit id or tag")
 set(TOOLCHAIN_TAG c527abce028df33f5281e9ed4994c25fcef53c7d CACHE STRING "vita-toolchain branch, commit id or tag")
 set(PTHREAD_TAG 11d2e5722d98c86f33c908fc47b2cf6e55205db5 CACHE STRING "pthread-embedded branch, commit id or tag")
-set(VDPM_TAG v0.1.2 CACHE STRING "vdpm branch, commit id or tag")
+set(VDPM_TAG v0.1.3 CACHE STRING "vdpm branch, commit id or tag")
 set(VITA_MAKEPKG_TAG 32f863c2a58a801b7d5a0296bdbbb443c9676e08 CACHE STRING "vita-makepkg branch, commit id or tag")


### PR DESCRIPTION
The bootstrap script does not only live in vdpm's releases: it ships inside every bundle, and the bundle is embedded in every core. So the cores published today carry a `share/vdpm/bootstrap-vitasdk.sh` that cannot install anything — v0.1.2's installer seeds from a release whose layout it rejects, and dies on `libexec/vdpm/pacman` regardless of the channel asked for.

v0.1.3 fixes it, verified in a clean container against the published channels.

Nothing else moves with the tag: the executor fetches the bundle by tag and verifies it against the checksum the release itself publishes, so there is no pinned digest here to follow it. Before the refactor this same bump would have been two repositories and four hand-copied hashes.

---
AI tools were used in preparing this PR (Claude Sonnet 5 and Claude Fable 5, Anthropic).