### PR TITLE
Guard a declared version the way a derived one is guarded

### DIFF
--- a/scripts/describe.py
+++ b/scripts/describe.py
@@ -223,11 +223,17 @@ def build_lock(revision, profile, previous_version):
     else:
         check_first_parent_date(resolved)
         version = nightly_version(resolved)
-        if previous_version is not None and vercmp(version, previous_version) <= 0:
-            raise DescribeError(
-                f"candidate version {version} does not exceed "
-                f"previous version {previous_version}"
-            )
+
+    # Both paths, and the declared one most of all: a nightly version is
+    # derived and cannot go backwards by accident, but a stable one is typed
+    # by a person. The caller passes the last version of the channel it is
+    # about to publish to -- comparing across channels is meaningless, since
+    # every nightly sorts below every stable.
+    if previous_version is not None and vercmp(version, previous_version) <= 0:
+        raise DescribeError(
+            f"candidate version {version} does not exceed "
+            f"previous version {previous_version}"
+        )
 
     return {
         "schema": SCHEMA,

--- a/tests/protocol/test-describe-monotonicity.sh
+++ b/tests/protocol/test-describe-monotonicity.sh
@@ -63,4 +63,27 @@ describe --profile vita --revision "$clean_rev" --previous-version "0.1.1" > /de
 	exit 1
 }
 
+# The declared path is the one a person types, so it is the one that most
+# needs the guard.
+printf '2026.08.0\n' > VERSION
+git add VERSION
+git commit -aq -m 'test: declare a stable version'
+stable_rev=$(git rev-parse HEAD)
+
+for refused in 2026.08.0 2026.09.0; do
+	if output=$(describe --profile vita --revision "$stable_rev" --previous-version "$refused" 2>&1); then
+		printf 'describe accepted declared 2026.08.0 against previous %s\n' "$refused" >&2
+		exit 1
+	fi
+	grep -qi 'previous version' <<< "$output" || {
+		printf 'describe did not name the previous-version guard: %s\n' "$output" >&2
+		exit 1
+	}
+done
+
+describe --profile vita --revision "$stable_rev" --previous-version "2026.07.9" > /dev/null || {
+	printf 'describe rejected a declared version that exceeds the previous one\n' >&2
+	exit 1
+}
+
 printf 'describe monotonicity guard contract tests passed\n'

--- a/tests/protocol/test-describe-version.sh
+++ b/tests/protocol/test-describe-version.sh
@@ -70,7 +70,7 @@ for (( i = ${#chain[@]} - 1; i >= 0; i-- )); do
 	previous_rev=$rev
 done
 
-# A committed VERSION file bypasses the nightly monotonicity gate entirely.
+# A committed VERSION file is used verbatim, not derived from the history.
 clone="$temporary_root/clone"
 git clone --quiet "$repository_root" "$clone"
 git -C "$clone" config user.email describe-tests@ci.invalid
@@ -81,7 +81,7 @@ git add VERSION
 git commit -aq -m 'test: declare a stable version'
 stable_rev=$(git rev-parse HEAD)
 
-stable_version=$(describe --profile vita --revision "$stable_rev" --previous-version 999.999.999 | field version)
+stable_version=$(describe --profile vita --revision "$stable_rev" | field version)
 [[ $stable_version == 2026.08.0 ]] || {
 	printf 'stable declaration was not used verbatim: got %s\n' "$stable_version" >&2
 	exit 1


### PR DESCRIPTION
The version `describe` computes becomes the pacman version of `vitasdk-core`, and pacman offers an upgrade only when the new version is greater than the installed one. A version that fails to increase therefore publishes a package nobody is ever offered, and says nothing while doing it. `--previous-version` is the guard against exactly that.

It covered half the job. A version derived from history (`0.<date>.<count>`) was checked; a version declared in a committed `VERSION` file was not — with `--previous-version 2026.09.0` in front of a `VERSION` reading `2026.08.1`, `describe` emitted the lock without a word. That is the wrong half: the derived number is a date and a commit count, which do not go backwards by accident, and the declared one is typed by a person. The check moves out of the `else` so both paths get it.

A test was asserting the hole rather than catching it. It passed `--previous-version 999.999.999` to a stable revision on purpose and expected success, under a comment explaining that a committed `VERSION` bypasses the gate. It now checks only what it is there to check: that the declaration is used verbatim. The monotonicity suite picks up the declared path — refused when equal or lower, accepted when higher.

No build changes today: nothing in production passes `--previous-version`, since `autobuilds` calls `describe` without it. Wiring the caller to pass it is separate work, and it will have to pass the last version of the channel it is about to publish to — the comparison only means something within one channel, as every nightly sorts below every stable.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
