### PR TITLE
Say in the lock which series a release belongs to

### DIFF
--- a/scripts/describe.py
+++ b/scripts/describe.py
@@ -195,6 +195,24 @@ def stable_version_declaration(revision):
     return value or None
 
 
+def release_series(declared):
+    """Which series a declared version is a release of.
+
+    A patch of 2026.08 is 2026.08.1 and the series it moves is 2026.08:
+    everything up to the last dot. A derived version has no series -- nightly
+    is a channel, not a series -- and says so with None, which is what keeps
+    a patch from being mistaken for a nightly by whoever publishes it.
+    """
+
+    if declared is None:
+        return None
+    series, dot, patch = declared.rpartition(".")
+    if not dot or not series or not patch:
+        raise DescribeError(
+            f"declared version '{declared}' is not <series>.<patch>")
+    return series
+
+
 def check_first_parent_date(revision):
     parent = first_parent(revision)
     if parent is None:
@@ -241,6 +259,10 @@ def build_lock(revision, profile, previous_version):
         "buildscripts_revision": resolved,
         "profile": profile,
         "version": version,
+        # Additive on purpose, without a schema bump: a reader that does not
+        # know the field behaves exactly as before, and bumping would make
+        # every shell already deployed reject every new lock.
+        "series": release_series(declared),
         "hosts": hosts,
         "sources": sources,
     }

--- a/tests/protocol/test-describe-version.sh
+++ b/tests/protocol/test-describe-version.sh
@@ -87,4 +87,42 @@ stable_version=$(describe --profile vita --revision "$stable_rev" | field versio
 	exit 1
 }
 
+# The series is what the publisher points at a new core. Getting it from the
+# lock is what stops a patch of 2026.08 being announced as a nightly, which
+# would drag every nightly user onto the series' older target runtime.
+stable_series=$(describe --profile vita --revision "$stable_rev" | field series)
+[[ $stable_series == 2026.08 ]] || {
+	printf 'declared version did not yield its series: got %s\n' "$stable_series" >&2
+	exit 1
+}
+
+printf '2026.08.1\n' > VERSION
+git commit -aq -m 'test: declare a patch of the same series'
+patch_series=$(describe --profile vita --revision "$(git rev-parse HEAD)" | field series)
+[[ $patch_series == 2026.08 ]] || {
+	printf 'a patch did not stay in its series: got %s\n' "$patch_series" >&2
+	exit 1
+}
+
+# A nightly has no series at all: it is a channel, not a release line.
+git rm -q VERSION
+git commit -aq -m 'test: back to a derived version'
+nightly_series=$(describe --profile vita --revision "$(git rev-parse HEAD)" | field series)
+[[ $nightly_series == None ]] || {
+	printf 'a derived version claimed a series: got %s\n' "$nightly_series" >&2
+	exit 1
+}
+
+printf 'nonsense\n' > VERSION
+git add VERSION
+git commit -aq -m 'test: declare a version with no patch level'
+if output=$(describe --profile vita --revision "$(git rev-parse HEAD)" 2>&1); then
+	printf 'describe accepted a declared version that is not <series>.<patch>\n' >&2
+	exit 1
+fi
+grep -qi 'series' <<< "$output" || {
+	printf 'describe did not say what was wrong with it: %s\n' "$output" >&2
+	exit 1
+}
+
 printf 'describe version derivation contract tests passed\n'


### PR DESCRIPTION
Publishing a patch means pointing a release series at a new core, and the lock did not say which series that is. The publisher had no way to know, so it announced every core the same way — and an announcement with no series names the unnamed one, which is nightly.

That was harmless while every core published was a nightly. `2026.08.1` would not have been: the series carries newlib `6cba9812`, 2445 commits behind the `892f530f` on the development branch, and announcing its core without a series would have moved every nightly user onto that older target runtime. Quietly, and without anyone asking.

The series belongs here rather than at the publisher because it is read off the declared version, and reading version strings is exactly what the publisher is meant not to do. `2026.08.1` yields `2026.08`: everything up to the last dot. A derived version yields `null`, because nightly is a channel rather than a release line, and a declared version that is not `<series>.<patch>` is refused by name.

The field is additive and `schema` stays at `1` on purpose. A reader that does not know it behaves exactly as it did — `parse-lock.py` compares the number and nothing else — while a bump would make every shell already deployed reject every new lock, which is a coordinated deploy for an optional field.

Four new assertions in the version contract tests: a release yields its series, a patch of the same series stays in it, a derived version yields none, and a declared version with no patch level fails saying so. They fail against the current implementation with `KeyError: 'series'`.

The matching change in `autobuilds` forwards this into the `core_published` payload.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
