### PR TITLE
Verify a cross where the machine can run what it built

### DIFF
--- a/cmake/hosts.json
+++ b/cmake/hosts.json
@@ -4,10 +4,10 @@
     {"name": "x86_64-linux-gnu", "stage": 2, "runner": "ubuntu-24.04", "container": "ubuntu:20.04", "packaged": true},
     {"name": "aarch64-linux-gnu", "stage": 2, "runner": "ubuntu-24.04-arm", "container": "ubuntu:20.04", "packaged": true},
     {"name": "arm64-apple-darwin", "stage": 2, "runner": "macos-14", "container": null, "packaged": true},
-    {"name": "x86_64-apple-darwin", "stage": 2, "runner": "macos-15-intel", "container": null, "packaged": true},
     {"name": "x86_64-linux-musl", "stage": 2, "runner": "ubuntu-24.04", "container": null, "packaged": true},
     {"name": "aarch64-linux-musl", "stage": 2, "runner": "ubuntu-24.04-arm", "container": null, "packaged": true},
     {"name": "x86_64-w64-mingw32", "stage": 3, "runner": "ubuntu-24.04", "container": null, "packaged": true, "build_host": "x86_64-linux-gnu"},
+    {"name": "x86_64-apple-darwin", "stage": 3, "runner": "macos-14", "container": null, "packaged": true, "build_host": "arm64-apple-darwin"},
     {"name": "i686-w64-mingw32", "stage": 3, "runner": "ubuntu-24.04", "container": null, "packaged": false, "build_host": "x86_64-linux-gnu"},
     {"name": "x86_64-unknown-freebsd", "stage": 3, "runner": "ubuntu-24.04", "container": null, "packaged": true, "build_host": "x86_64-linux-gnu"},
     {"name": "aarch64-unknown-freebsd", "stage": 3, "runner": "ubuntu-24.04", "container": null, "packaged": true, "build_host": "x86_64-linux-gnu"}

--- a/cmake/recipes/FinalizeSdk.cmake
+++ b/cmake/recipes/FinalizeSdk.cmake
@@ -126,9 +126,17 @@ add_custom_target(finalize-sdk
     VERBATIM
     )
 
+# Empty when the host's binaries run here as they are. A cross whose output
+# this machine can still execute -- x86_64 macOS on arm64, through Rosetta --
+# sets it to the launcher that makes that true, so the contract runs against
+# the SDK that was actually built rather than being skipped.
+set(VITASDK_HOST_RUNNER "" CACHE STRING
+    "Launcher prefix for running this host's binaries, if one is needed")
+
 add_custom_target(check-toolchain-contract
     COMMAND ${CMAKE_COMMAND} -E env
         VITASDK=${CMAKE_INSTALL_PREFIX}
+        ${VITASDK_HOST_RUNNER}
         ${CMAKE_SOURCE_DIR}/tests/toolchain-contract/run.sh
     DEPENDS finalize-sdk
     VERBATIM

--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -105,6 +105,25 @@ trap dump_configure_logs EXIT
 # The matrix's packaged flag, not the host name, gates core-package treatment.
 is_packaged_host() { [[ $packaged == true ]]; }
 
+# How to run this host's binaries on this machine, if at all. Prints the
+# launcher prefix and succeeds; fails when there is none.
+#
+# What this replaces was "only a native build can run its own output", which
+# is true of a canadian cross to Windows or FreeBSD and false of Apple: an
+# arm64 Mac runs x86_64 Mach-O through Rosetta, so the machine that
+# cross-builds the Intel SDK is also the one that can check it.
+host_runner() {
+	if [[ -z $build_host ]]; then
+		printf ''
+		return 0
+	fi
+	if [[ $host == x86_64-apple-darwin && $build_host == arm64-apple-darwin ]]; then
+		printf 'arch -x86_64'
+		return 0
+	fi
+	return 1
+}
+
 vdpm_tag() {
 	sed -n 's/^set(VDPM_TAG \([^ )]*\).*/\1/p' "$repo_root/cmake/Components.cmake"
 }
@@ -133,14 +152,17 @@ download_vdpm_bundle() {
 # Same-runner smoke test only; a canadian cross cannot run what it built.
 smoke_test_bootstrap() {
 	local bootstrap_archive=$1 digest install_root
+	# Empty for a host that runs here directly; a launcher for one that needs
+	# it. Unquoted on purpose, so an empty prefix contributes no argument.
+	local -a run=(${2:-})
 	digest=$(awk '{print $1}' "$bootstrap_archive.sha256")
 	install_root="$PWD/bootstrap-installed"
 	VITASDK_BOOTSTRAP_ARCHIVE="$bootstrap_archive" VITASDK_BOOTSTRAP_SHA256="$digest" \
-		build/vitasdk/share/vdpm/bootstrap-vitasdk.sh --install-dir "$install_root"
-	VITASDK="$install_root" "$install_root/bin/vdpm" --help >/dev/null
+		"${run[@]}" build/vitasdk/share/vdpm/bootstrap-vitasdk.sh --install-dir "$install_root"
+	VITASDK="$install_root" "${run[@]}" "$install_root/bin/vdpm" --help >/dev/null
 	# vdpm ships pacman under libexec/vdpm, not bin/.
-	"$install_root/libexec/vdpm/pacman" --version >/dev/null
-	"$install_root/bin/arm-vita-eabi-gcc" --version
+	"${run[@]}" "$install_root/libexec/vdpm/pacman" --version >/dev/null
+	"${run[@]}" "$install_root/bin/arm-vita-eabi-gcc" --version
 }
 
 # Builds against $stage1_dir if set, then stages outputs plus provenance.
@@ -155,6 +177,7 @@ build_and_stage() {
 		# The lock names the host; artifacts published under any other name
 		# would not match what the caller asked to be built.
 		-DVITASDK_HOST_NAME="$host"
+		-DVITASDK_HOST_RUNNER="$(host_runner || true)"
 	)
 	[[ -n ${stage1_dir:-} ]] && cmake_args+=(-DVITASDK_STAGE1_DIR="$stage1_dir")
 	local -a targets=(tarball)
@@ -175,12 +198,14 @@ build_and_stage() {
 	cmake --build build --target "${targets[@]}" --parallel "$(ci_nproc)"
 	report_ccache_statistics
 
-	# Only a native build can run its own output.
-	if [[ -z $build_host ]]; then
+	# Verified wherever it can be run, which is not the same as natively.
+	if runner=$(host_runner); then
 		cmake --build build --target check-toolchain-contract
 		if is_packaged_host; then
-			smoke_test_bootstrap "build/bootstraps/vitasdk-bootstrap-$host.tar.bz2"
+			smoke_test_bootstrap "build/bootstraps/vitasdk-bootstrap-$host.tar.bz2" "$runner"
 		fi
+	else
+		printf 'no way to run %s binaries here; contract and smoke test skipped\n' "$host"
 	fi
 
 	stage_and_write_provenance

--- a/tests/ci/test-host-runner.sh
+++ b/tests/ci/test-host-runner.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Which hosts get their output verified, and how it is run.
+#
+# build-host.sh used to ask "is this native?", which skipped the toolchain
+# contract and the bootstrap smoke test for every cross. That is right for a
+# canadian cross to Windows or FreeBSD and wrong for Apple: an arm64 Mac runs
+# x86_64 Mach-O through Rosetta, so the machine that cross-builds the Intel
+# SDK is the one that can check it. Getting this wrong is silent -- the host
+# publishes either way, just unverified.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+script="$repository_root/scripts/ci/build-host.sh"
+
+failures=0
+
+# host_runner() reads $host and $build_host from the script's scope, so it is
+# exercised the way the script calls it rather than through the CLI, which
+# would need a whole toolchain to reach the same line.
+runner_for()
+{
+	host=$1 build_host=$2 bash -c '
+		host=$host
+		build_host=$build_host
+		'"$(sed -n '/^host_runner()/,/^}/p' "$script")"'
+		if runner=$(host_runner); then
+			printf "runs:%s" "$runner"
+		else
+			printf "cannot"
+		fi
+	'
+}
+
+check()
+{
+	description=$1
+	actual=$(runner_for "$2" "$3")
+	if [[ $actual != "$4" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' \
+			"$description" "$4" "$actual" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+# Native: runs directly, no launcher.
+check "a native host runs its own output" \
+	x86_64-linux-gnu "" "runs:"
+check "a native Mac runs its own output" \
+	arm64-apple-darwin "" "runs:"
+
+# The case this exists for.
+check "an arm64 Mac runs the Intel SDK it cross-built" \
+	x86_64-apple-darwin arm64-apple-darwin "runs:arch -x86_64"
+
+# The cases where the old comment was right and must stay right.
+check "a Linux box cannot run Windows binaries" \
+	x86_64-w64-mingw32 x86_64-linux-gnu "cannot"
+check "a Linux box cannot run FreeBSD binaries" \
+	x86_64-unknown-freebsd x86_64-linux-gnu "cannot"
+check "a Linux box cannot run the Intel Mac SDK either" \
+	x86_64-apple-darwin x86_64-linux-gnu "cannot"
+
+# Rosetta goes one way only: an Intel Mac does not run arm64.
+check "an Intel Mac cannot run an arm64 Mac SDK" \
+	arm64-apple-darwin x86_64-apple-darwin "cannot"
+
+# Which packaged hosts this script cannot run, pinned so that adding one
+# passes somebody's eyes. Windows is on the list and is still verified: a
+# dedicated job smoke-tests its bootstrap on a real Windows runner. The two
+# FreeBSD hosts are on it and are verified nowhere, which is a gap this test
+# records rather than fixes -- closing it needs a FreeBSD VM, not Rosetta.
+unverified=$(python3 - "$repository_root/cmake/hosts.json" <<'PYTHON'
+import json, sys
+hosts = json.load(open(sys.argv[1]))["hosts"]
+out = []
+for h in hosts:
+    if not h["packaged"]:
+        continue
+    build_host = h.get("build_host")
+    if not build_host:
+        continue
+    if h["name"] == "x86_64-apple-darwin" and build_host == "arm64-apple-darwin":
+        continue
+    out.append(h["name"])
+print(" ".join(sorted(out)))
+PYTHON
+)
+expected="aarch64-unknown-freebsd x86_64-unknown-freebsd x86_64-w64-mingw32"
+if [[ $unverified != "$expected" ]]; then
+	printf 'FAIL: the set of hosts this script cannot run changed\n  expected: %s\n  actual:   %s\n' \
+		"$expected" "$unverified" >&2
+	failures=$((failures + 1))
+fi
+
+if (( failures )); then
+	printf '%d host-runner check(s) failed\n' "$failures" >&2
+	exit 1
+fi
+
+printf 'host runner contract tests passed\n'


### PR DESCRIPTION
`x86_64-apple-darwin` became a native build in #161 for a good reason: nothing ever executed what the cross produced, so it had no toolchain contract and no bootstrap smoke test, and a host nobody can check is a host that should not publish. Native fixed that and cost the time. In the first real nine-host publication it took **62m22s** against **14m03s** for its arm64 sibling on the same run, and every stage-3 host waits behind it.

The line that decided this reads:

```bash
# Only a native build can run its own output.
if [[ -z $build_host ]]; then
```

True of a canadian cross to Windows or FreeBSD. Not true of Apple: an arm64 Mac runs x86_64 Mach-O through Rosetta, so the machine that cross-builds the Intel SDK is the same one that can execute and check it.

So the question changes from *is this native* to *how do I run this host's binaries here*. `host_runner` answers with a launcher prefix — empty for a native host, `arch -x86_64` for the Intel Mac SDK built on arm64 — or fails for a host nothing here can execute. Both the contract and the smoke test take that prefix, and `check-toolchain-contract` gets it through a new `VITASDK_HOST_RUNNER` cache variable so the invocation stays in one place rather than being duplicated into the shell script.

Windows and FreeBSD answer "cannot" and are skipped exactly as they were, and the skip now says so instead of being silent.

**Measured before writing any of this**, in `frangarcj/vitasdk-ci-probe`, on `macos-14`:

| | |
|---|---|
| cross build | 650s |
| compiler runs under Rosetta | 0s |
| toolchain contract under Rosetta | 24s |
| bootstrap smoke under Rosetta | 30s |
| **whole job** | **12m18s** |
| native on `macos-15-intel`, for comparison | 62m22s |

The smoke test there was the real one — install from the bootstrap archive against its sha256, then `vdpm --help`, `libexec/vdpm/pacman --version` and `arm-vita-eabi-gcc --version` — and the contract included `checking that public headers compile on their own`, which is the check that caught two broken headers earlier today.

`tests/ci/test-host-runner.sh` covers the seven cases, including the two directions Rosetta does not go: a Linux box cannot run the Intel Mac SDK, and an Intel Mac cannot run an arm64 one. It also pins the set of packaged hosts this script cannot run — Windows and the two FreeBSD ones — so adding another passes somebody's eyes. Windows stays verified by its own job on a real Windows runner; the two FreeBSD hosts are verified nowhere, which that test records as a gap rather than fixes, since closing it needs a FreeBSD VM and not Rosetta.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
