### PR TITLE
Let the protocol tests run on a branch that declares a version

### DIFF
--- a/tests/protocol/test-describe-monotonicity.sh
+++ b/tests/protocol/test-describe-monotonicity.sh
@@ -22,6 +22,15 @@ field() {
 
 cd "$clone"
 
+# The clone inherits whatever branch this runs from, and a release branch
+# carries a VERSION. Everything below exercises the derived path, which a
+# declared version turns off -- so the clone starts without one rather than
+# assuming the branch has none.
+if git cat-file -e HEAD:VERSION 2>/dev/null; then
+	git rm -q VERSION
+	git commit -aq -m 'test: derive versions rather than read them'
+fi
+
 # describe fails when the candidate's committer date precedes its parent's.
 parent_epoch=$(git log -1 --format=%ct HEAD)
 skewed_epoch=$(( parent_epoch - 3600 ))

--- a/tests/protocol/test-describe-version.sh
+++ b/tests/protocol/test-describe-version.sh
@@ -19,6 +19,9 @@ vercmp() {
 	python3 "$repository_root/scripts/vercmp.py" "$1" "$2"
 }
 
+# The same file describe reads to decide a version is declared.
+VERSION_PATH=VERSION
+
 cd "$repository_root"
 head_rev=$(git rev-parse HEAD)
 
@@ -39,20 +42,31 @@ version_b=$(describe --profile vita --revision "$head_rev" | field version)
 # The walkable range starts where describe's own files were introduced, not history's root.
 introduced=$(git log --first-parent --format=%H --diff-filter=A -- cmake/Profiles.cmake | tail -1)
 range_count=$(git rev-list --first-parent --count "${introduced}~1..$head_rev")
-# A PR merge ref's first parent is master, where describe's files do not
-# exist yet, so the walkable range collapses to the merge commit alone.
-# The guards themselves are covered by the synthetic-history test; the
-# real-history walk waits for a ref that carries it (any master push).
-(( range_count >= 2 )) || {
-	printf 'skipping the real-history walk: %s describe-capable commit(s) on the first-parent line\n' \
-		"$range_count"
-	exit 0
-}
+
+# Reasons the walk has nothing to walk. Neither is a failure, and neither
+# stops the checks below it: skipping used to exit, which took the stable
+# declaration with it on exactly the branches that have one.
+skip_walk=""
+if git cat-file -e "$head_rev:$VERSION_PATH" 2>/dev/null; then
+	# Every commit on a release branch answers with what VERSION says, so
+	# there is no derived version here to be monotonic. The derivation and
+	# its guards are covered by the synthetic-history test, which builds
+	# the history it needs instead of borrowing this one.
+	skip_walk="$head_rev declares a version"
+elif (( range_count < 2 )); then
+	# A PR merge ref's first parent is master, where describe's files do not
+	# exist yet, so the walkable range collapses to the merge commit alone.
+	skip_walk="$range_count describe-capable commit(s) on the first-parent line"
+fi
 
 chain=()
-while read -r rev; do
-	chain+=("$rev")
-done < <(git rev-list --first-parent "${introduced}~1..$head_rev")
+if [[ -n $skip_walk ]]; then
+	printf 'skipping the real-history walk: %s\n' "$skip_walk"
+else
+	while read -r rev; do
+		chain+=("$rev")
+	done < <(git rev-list --first-parent "${introduced}~1..$head_rev")
+fi
 
 previous_version=
 previous_rev=


### PR DESCRIPTION
Tagging `vitasdk-2026.08.1` turned its CI red, and every release branch and tag after it would have gone the same way.

The thirteen build jobs pass on that tree — the patch builds nine hosts. What fails is two protocol tests, both for the same reason: they assume the repository derives its version, and a release branch is precisely the thing that does not.

**The version test** walks real first-parent history asserting each version precedes the next under `vercmp`. On a release branch every commit answers with the same declared string, so the first comparison it makes is `2026.08.1` against `2026.08.1`:

```
2026.08.1 (b8d12c7e5) does not precede 2026.08.1 (d85575026) under vercmp
```

It already knows how to say a walk has nothing to walk — a PR merge ref collapses the range to one commit — so a declared version becomes the second reason for the same skip. The skip no longer `exit 0`s: the checks below it are about declared versions, and they were being skipped on exactly the branches that have one.

**The monotonicity test** starts by committing a clock-skewed revision and expecting `describe` to refuse it. That guard only runs on the derived path:

```python
if declared is not None:
    version = declared
else:
    check_first_parent_date(resolved)
    version = nightly_version(resolved)
```

so on a release branch `describe` takes the declared path, never checks the date, and the test sees a success where it wanted a refusal. It builds its own history in a clone and exercises the derived path throughout, so the clone now drops `VERSION` if the branch it came from carries one.

Neither change touches `describe`. The date check has nothing to say about a version a person typed, and the declared path is guarded by the previous-version gate instead.

Verified both ways: six of six on `master`, and six of six on `next-patch-2026.08.1`, where the skip says which revision declared a version rather than passing silently.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
