### PR TITLE
Let a host that needs no launcher run its own smoke test

### DIFF
--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -157,12 +157,15 @@ smoke_test_bootstrap() {
 	local -a run=(${2:-})
 	digest=$(awk '{print $1}' "$bootstrap_archive.sha256")
 	install_root="$PWD/bootstrap-installed"
+	# ${run[@]+...}: macOS's /bin/bash is 3.2, where expanding an empty array
+	# under set -u is an unbound-variable error -- and empty is the normal
+	# case here, for every host that runs its own binaries.
 	VITASDK_BOOTSTRAP_ARCHIVE="$bootstrap_archive" VITASDK_BOOTSTRAP_SHA256="$digest" \
-		"${run[@]}" build/vitasdk/share/vdpm/bootstrap-vitasdk.sh --install-dir "$install_root"
-	VITASDK="$install_root" "${run[@]}" "$install_root/bin/vdpm" --help >/dev/null
+		${run[@]+"${run[@]}"} build/vitasdk/share/vdpm/bootstrap-vitasdk.sh --install-dir "$install_root"
+	VITASDK="$install_root" ${run[@]+"${run[@]}"} "$install_root/bin/vdpm" --help >/dev/null
 	# vdpm ships pacman under libexec/vdpm, not bin/.
-	"${run[@]}" "$install_root/libexec/vdpm/pacman" --version >/dev/null
-	"${run[@]}" "$install_root/bin/arm-vita-eabi-gcc" --version
+	${run[@]+"${run[@]}"} "$install_root/libexec/vdpm/pacman" --version >/dev/null
+	${run[@]+"${run[@]}"} "$install_root/bin/arm-vita-eabi-gcc" --version
 }
 
 # Builds against $stage1_dir if set, then stages outputs plus provenance.

--- a/scripts/ci/build-host.sh
+++ b/scripts/ci/build-host.sh
@@ -197,8 +197,8 @@ build_and_stage() {
 		targets+=(core-package bootstrap-archive)
 	fi
 
-	cmake "${cmake_args[@]}"
-	cmake --build build --target "${targets[@]}" --parallel "$(ci_nproc)"
+	cmake ${cmake_args[@]+"${cmake_args[@]}"}
+	cmake --build build --target ${targets[@]+"${targets[@]}"} --parallel "$(ci_nproc)"
 	report_ccache_statistics
 
 	# Verified wherever it can be run, which is not the same as natively.
@@ -224,7 +224,7 @@ stage_and_write_provenance() {
 	fi
 	local -a names=()
 	local file
-	for file in "${produced[@]}"; do
+	for file in ${produced[@]+"${produced[@]}"}; do
 		[[ -f $file ]] || continue
 		cp "$file" "$out_dir/"
 		names+=("$(basename "$file")")
@@ -271,7 +271,7 @@ build_musl_host() {
 	# so the container reaches the same cache the runner restored.
 	docker run --rm \
 		-v "$PWD":/src -w /src \
-		"${docker_env[@]}" \
+		${docker_env[@]+"${docker_env[@]}"} \
 		alpine:3.20 sh -eux -c '
 			apk add --no-cache bash build-base cmake git autoconf automake \
 				libtool libarchive-tools texinfo bison flex pkgconf curl xz \
@@ -322,12 +322,12 @@ install_dependencies() {
 		i686-w64-mingw32) extra=(g++-mingw-w64-i686) ;;
 		x86_64-unknown-freebsd | aarch64-unknown-freebsd) extra=(clang lld llvm) ;;
 		esac
-		"${sudo_cmd[@]}" apt-get update -qq
-		"${sudo_cmd[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+		${sudo_cmd[@]+"${sudo_cmd[@]}"} apt-get update -qq
+		${sudo_cmd[@]+"${sudo_cmd[@]}"} env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
 			cmake cmake-data git build-essential autoconf automake libtool \
 			texinfo bison flex pkg-config python3 python3-pip curl bzip2 xz-utils \
 			libarchive-tools ccache \
-			"${extra[@]}"
+			${extra[@]+"${extra[@]}"}
 		pip3 install --quiet cmake==3.31.6
 		;;
 	esac
@@ -342,7 +342,7 @@ enable_ccache() {
 		shims="$(brew --prefix ccache)/libexec"
 	else
 		[[ -x /usr/sbin/update-ccache-symlinks ]] &&
-			"${sudo_cmd[@]}" /usr/sbin/update-ccache-symlinks
+			${sudo_cmd[@]+"${sudo_cmd[@]}"} /usr/sbin/update-ccache-symlinks
 		shims=/usr/lib/ccache
 	fi
 	[[ -d $shims ]] || {

--- a/scripts/create-bootstrap-archive.sh
+++ b/scripts/create-bootstrap-archive.sh
@@ -31,7 +31,7 @@ case $host in
 			bin/include/refresh-repositories.sh)
 		;;
 esac
-for relative_path in "${required[@]}"; do
+for relative_path in ${required[@]+"${required[@]}"}; do
 	[[ -e $sdk_root/$relative_path ]] || {
 		printf 'bootstrap SDK is missing %s\n' "$relative_path" >&2
 		exit 1

--- a/scripts/create-core-package.sh
+++ b/scripts/create-core-package.sh
@@ -97,7 +97,7 @@ cp -a "$sdk_root/." "$core_root/"
 rm -f "$core_root/.PKGINFO" "$core_root/.BUILDINFO" "$core_root/.MTREE" \
 	"$core_root/etc/pacman.conf"
 
-for path in "${client_paths[@]}"; do
+for path in ${client_paths[@]+"${client_paths[@]}"}; do
 	[[ -e $core_root/$path ]] || {
 		printf 'the SDK does not carry %s\n' "$path" >&2
 		exit 1

--- a/scripts/create-core-repositories.sh
+++ b/scripts/create-core-repositories.sh
@@ -93,13 +93,13 @@ normalize_database() {
 }
 
 mapfile -t sorted_architectures < <(printf '%s\n' "${!architectures[@]}" | LC_ALL=C sort)
-for architecture in "${sorted_architectures[@]}"; do
+for architecture in ${sorted_architectures[@]+"${sorted_architectures[@]}"}; do
 	read -r -a package_filenames <<<"${architectures[$architecture]}"
 	packages=()
-	for package_filename in "${package_filenames[@]}"; do
+	for package_filename in ${package_filenames[@]+"${package_filenames[@]}"}; do
 		packages+=("$staging_directory/$package_filename")
 	done
-	repo-add "$staging_directory/$architecture.db.tar.gz" "${packages[@]}"
+	repo-add "$staging_directory/$architecture.db.tar.gz" ${packages[@]+"${packages[@]}"}
 	normalize_database "$staging_directory/$architecture.db.tar.gz" \
 		"$temporary_directory/$architecture.db"
 	normalize_database "$staging_directory/$architecture.files.tar.gz" \
@@ -177,10 +177,10 @@ if [[ -n ${RELEASE_SCHEMA:-}${RELEASE_BUILD_ID:-}${RELEASE_BUILDSCRIPTS_REVISION
 	}
 
 	host_fragments=()
-	for architecture in "${sorted_architectures[@]}"; do
+	for architecture in ${sorted_architectures[@]+"${sorted_architectures[@]}"}; do
 		host_artifacts=("$architecture.db" "$architecture.files")
 		read -r -a package_filenames <<<"${architectures[$architecture]}"
-		host_artifacts+=("${package_filenames[@]}")
+		host_artifacts+=(${package_filenames[@]+"${package_filenames[@]}"})
 		while IFS= read -r -d '' extra; do
 			host_artifacts+=("$(basename "$extra")")
 		done < <(find "$staging_directory" -maxdepth 1 -type f \
@@ -191,7 +191,7 @@ if [[ -n ${RELEASE_SCHEMA:-}${RELEASE_BUILD_ID:-}${RELEASE_BUILDSCRIPTS_REVISION
 			printf 'no provenance echo found for published host: %s\n' "$architecture" >&2
 			exit 1
 		}
-		host_fragments+=("{\"name\":\"$(json_escape "$architecture")\",\"build_id\":\"$(json_escape "$build_id")\",\"artifacts\":$(json_string_array "${host_artifacts[@]}")}")
+		host_fragments+=("{\"name\":\"$(json_escape "$architecture")\",\"build_id\":\"$(json_escape "$build_id")\",\"artifacts\":$(json_string_array ${host_artifacts[@]+"${host_artifacts[@]}"})}")
 	done
 
 	hosts_joined=$(

--- a/scripts/install-vdpm-bundle.sh
+++ b/scripts/install-vdpm-bundle.sh
@@ -64,7 +64,7 @@ else
 		bin/include/refresh-repositories.sh
 	)
 fi
-for relative_path in "${required[@]}"; do
+for relative_path in ${required[@]+"${required[@]}"}; do
 	[[ -f $root/$relative_path && ! -L $root/$relative_path ]] || {
 		printf 'vdpm bundle is missing required regular file: %s\n' "$relative_path" >&2
 		exit 1

--- a/tests/ci/test-empty-array-expansion.sh
+++ b/tests/ci/test-empty-array-expansion.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Arrays that reach a published host must expand the way bash 3.2 tolerates.
+#
+# macOS runners are the reason. Their /bin/bash is 3.2, where expanding an
+# empty array under `set -u` is an unbound-variable error rather than
+# nothing, and the failure comes after a complete build: the SDK is
+# finalized and validated, then the script dies and stages nothing. It has
+# happened twice -- once fixed in "Expand possibly-empty arrays the way
+# macOS's bash 3.2 tolerates", then reintroduced with the Rosetta launcher,
+# which is empty for every host that runs its own binaries.
+#
+# The rule is mechanical on purpose. Deciding case by case which array can
+# be empty is exactly the judgement that failed: `${name[@]+"${name[@]}"}`
+# means the same thing as `"${name[@]}"` whenever the array has elements,
+# so requiring it everywhere costs nothing and needs no judgement.
+
+set -euo pipefail
+
+repository_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+
+offenders=$(python3 - "$repository_root" <<'PYEOF'
+import glob, os, re, sys
+
+root = sys.argv[1]
+# Value expansions only: ${#name[@]} and ${!name[@]} are fine in 3.2.
+plain = re.compile(r'"\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}"')
+tolerant = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\+"\$\{\1\[@\]\}"\}')
+
+for path in sorted(glob.glob(os.path.join(root, "scripts", "**", "*.sh"), recursive=True)):
+    with open(path, encoding="utf-8") as handle:
+        for number, line in enumerate(handle, 1):
+            if plain.search(tolerant.sub("", line)):
+                print(f"{os.path.relpath(path, root)}:{number}:{line.rstrip()}")
+PYEOF
+)
+
+if [[ -n $offenders ]]; then
+	printf 'these expansions die on macOS bash 3.2 when the array is empty;\n' >&2
+	printf 'write ${name[@]+"${name[@]}"} instead:\n\n%s\n' "$offenders" >&2
+	exit 1
+fi
+
+printf 'empty-array expansion: all checks passed\n'


### PR DESCRIPTION
Every macOS leg of the executor has been dying since the Rosetta gate landed, after a complete and valid build. From the arm64 job of `vitasdk/autobuilds#36`:

```
21:55:13  self-contained headers OK (73 checked)
21:55:18  Vita GCC/binutils contract OK
21:55:18  [100%] Built target check-toolchain-contract
21:55:18  scripts/ci/build-host.sh: line 160: run[@]: unbound variable
21:55:19  ##[error]No files were found with the provided path: out/*. No artifacts will be uploaded.
```

The SDK is finalized, the static validation passes, the toolchain contract passes, and then the script exits and stages nothing. The Intel host fails behind it for the reason it should — `no build-machine SDK found for x86_64-apple-darwin (needs arm64-apple-darwin)` — because the arm64 artifact it cross-builds from was never uploaded. `arm64-apple-darwin` is a required host, so **no snapshot can publish at all**; the last one that did, `sdk-snapshot-20260825.612.1`, was built from `79a92784`, the commit before this landed.

`smoke_test_bootstrap`'s launcher prefix is an array that is empty for every host that runs its own binaries — the comment above it says so — and macOS's `/bin/bash` is 3.2:

```
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ /bin/bash -c 'set -u; run=(); "${run[@]}" echo hola'
/bin/bash: run[@]: unbound variable
$ /bin/bash -c 'set -u; run=(); ${run[@]+"${run[@]}"} echo hola'
hola
$ /bin/bash -c 'set -u; run=(arch -x86_64); ${run[@]+"${run[@]}"} uname -m'
x86_64
```

`build_and_stage()` already carries the tolerant form, and the reason for it, three lines below the break.

**The second commit is separable** — take only the first if you would rather. This is the second time the same class has hit this file: fixed once in `9233c494a`, reintroduced by the launcher. Deciding case by case which array can be empty is the judgement that failed, so every expansion in the scripts that run on a published host takes the tolerant form, and a test refuses any that do not. Run against the parent of this branch it names lines 161–165 of `build-host.sh` — the ones that broke the nightly:

```
$ tests/ci/test-empty-array-expansion.sh
scripts/ci/build-host.sh:161:  "${run[@]}" build/vitasdk/share/vdpm/bootstrap-vitasdk.sh --install-dir "$install_root"
scripts/ci/build-host.sh:162:  VITASDK="$install_root" "${run[@]}" "$install_root/bin/vdpm" --help >/dev/null
...
```

The test is static because it has to be: `BASH_COMPAT=32` does not restore the 3.2 behaviour, so nothing on a Linux runner reproduces this by executing. The rewrite is mechanical and means the same thing whenever the array has elements; `${#name[@]}` and `${!name[@]}` are fine in 3.2 and are left alone. `tests/` is outside the rule — it runs on ubuntu only.

Every suite in the `checks` job passes locally, and both bashes parse every rewritten script (`bash -n`, `/bin/bash -n`). `tests/package/test-vdpm-bundle.sh` fails here with and without this change: it wants a stage-1 SDK, and it is not in `checks`.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
