### PR TITLE
Hand the contract a launcher it can execute

### DIFF
--- a/cmake/HostRunner.cmake
+++ b/cmake/HostRunner.cmake
@@ -1,0 +1,10 @@
+include_guard(GLOBAL)
+
+# A launcher prefix arrives as one string -- "arch -x86_64" -- and has to
+# reach COMMAND as separate arguments. Under VERBATIM a string with a space
+# in it is one argv[0], so the run dies with "no such file or directory"
+# naming nothing, after the whole SDK has been built.
+function(vitasdk_host_runner_command output runner)
+    separate_arguments(parts NATIVE_COMMAND "${runner}")
+    set(${output} ${parts} PARENT_SCOPE)
+endfunction()

--- a/cmake/recipes/FinalizeSdk.cmake
+++ b/cmake/recipes/FinalizeSdk.cmake
@@ -130,13 +130,16 @@ add_custom_target(finalize-sdk
 # this machine can still execute -- x86_64 macOS on arm64, through Rosetta --
 # sets it to the launcher that makes that true, so the contract runs against
 # the SDK that was actually built rather than being skipped.
+include(${CMAKE_CURRENT_LIST_DIR}/../HostRunner.cmake)
+
 set(VITASDK_HOST_RUNNER "" CACHE STRING
     "Launcher prefix for running this host's binaries, if one is needed")
+vitasdk_host_runner_command(vitasdk_host_runner_argv "${VITASDK_HOST_RUNNER}")
 
 add_custom_target(check-toolchain-contract
     COMMAND ${CMAKE_COMMAND} -E env
         VITASDK=${CMAKE_INSTALL_PREFIX}
-        ${VITASDK_HOST_RUNNER}
+        ${vitasdk_host_runner_argv}
         ${CMAKE_SOURCE_DIR}/tests/toolchain-contract/run.sh
     DEPENDS finalize-sdk
     VERBATIM

--- a/tests/cmake/host-runner-command.cmake
+++ b/tests/cmake/host-runner-command.cmake
@@ -1,0 +1,50 @@
+# A launcher with arguments has to reach the command as arguments.
+#
+# The Rosetta gate runs the Intel macOS contract through `arch -x86_64`, and
+# that arrives from the shell as one string. Interpolated into a VERBATIM
+# COMMAND it became a single argv[0] with a space in it, so the run died with
+#
+#     no such file or directory
+#
+# naming nothing, after the whole SDK had been built and validated. The Intel
+# host is cross-built, so this is the only thing that executes what it made.
+
+cmake_minimum_required(VERSION 3.20)
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/HostRunner.cmake)
+
+function(check_length description runner expected)
+    vitasdk_host_runner_command(parts "${runner}")
+    list(LENGTH parts length)
+    if(NOT length EQUAL expected)
+        message(SEND_ERROR "${description}: expected ${expected} argument(s), got ${length}: ${parts}")
+    endif()
+endfunction()
+
+check_length("a host that runs its own binaries needs no launcher" "" 0)
+check_length("a launcher with an argument stays two arguments" "arch -x86_64" 2)
+check_length("a launcher with several arguments keeps them all" "qemu-aarch64 -L /sysroot" 3)
+
+vitasdk_host_runner_command(runner_argv "arch -x86_64")
+list(GET runner_argv 0 first)
+if(NOT first STREQUAL "arch")
+    message(SEND_ERROR "the launcher itself is not the first argument: ${first}")
+endif()
+
+# The shape the target uses, run for real: a two-word launcher, an
+# environment, and a command behind it. cmake -E env is the launcher here
+# because it exists wherever this test runs.
+vitasdk_host_runner_command(launcher "${CMAKE_COMMAND} -E env")
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env VITASDK=irrelevant
+        ${launcher}
+        ${CMAKE_COMMAND} -E echo the-contract-ran
+    OUTPUT_VARIABLE output
+    RESULT_VARIABLE status
+    ERROR_VARIABLE errors)
+string(STRIP "${output}" output)
+if(NOT status EQUAL 0 OR NOT output STREQUAL "the-contract-ran")
+    message(SEND_ERROR "a launcher with arguments did not reach the command: status ${status}, output '${output}', errors '${errors}'")
+endif()
+
+message(STATUS "host runner command: all checks passed")


### PR DESCRIPTION
The Intel macOS host built its whole SDK, validated it, and then died naming nothing. From `vitasdk/autobuilds#36` after #168 landed:

```
23:29:27  -- Validated SDK at .../build/vitasdk
23:29:28  -- Static target SDK validation passed
23:29:47  Host dependency audit passed
23:29:47  [100%] Built target finalize-sdk
23:29:47  no such file or directory
23:29:47  make[3]: *** [CMakeFiles/check-toolchain-contract] Error 1
```

`VITASDK_HOST_RUNNER` carries the launcher that lets an arm64 machine run what it cross-built — `arch -x86_64` — and it arrives from the shell as one string. Interpolated into a `VERBATIM` `COMMAND`, a string with a space in it is a single `argv[0]`, so what got looked up on disk was a program named `arch -x86_64`:

```
$ cmake -E env FOO=1 "arch -x86_64" cmake -E echo ran
no such file or directory
$ cmake -E env FOO=1 arch -x86_64 cmake -E echo ran
arch: posix_spawnp: /opt/homebrew/bin/cmake: Bad CPU type in executable
```

The second message is this arm64 laptop refusing to run its own arm64 cmake under `arch -x86_64`, which is the point: the launcher was reached and did its job. On the runner the binary behind it is the x86_64 SDK, and Rosetta runs it.

`x86_64-apple-darwin` is cross-built, so `check-toolchain-contract` is the only thing that executes what it produced. Without it the host publishes unverified — the situation `db4d1a593` was written to end.

**Second defect of the same commit, and it was hidden behind the first.** While `run[@]: unbound variable` was killing the arm64 leg, the Intel job stopped at `no build-machine SDK found for x86_64-apple-darwin (needs arm64-apple-darwin)` and never got near the contract. Fixing #168 is what let this one surface.

`tests/cmake/host-runner-command.cmake` runs the shape the target uses — an environment, a two-word launcher, a command behind it — with `cmake -E env` as the launcher, because that exists wherever the test runs. Against a runner that is not split it fails three ways:

```
a launcher with an argument stays two arguments: expected 2 argument(s), got 1
a launcher with several arguments keeps them all: expected 3 argument(s), got 1
a launcher with arguments did not reach the command: status 1, output ''
```

The split lives in `cmake/HostRunner.cmake` so the test can call the same function the target does, rather than a copy of it. The shell side is unchanged: `smoke_test_bootstrap` splits the same string on whitespace into an array, which is correct there.

Every suite in the `checks` job passes locally.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).
