### PR TITLE
Take the vita-makepkg that finds the package client

### DIFF
--- a/cmake/Components.cmake
+++ b/cmake/Components.cmake
@@ -75,4 +75,4 @@ set(HEADERS_TAG 4f9b5d712751afef804a44d1d248ab2b358cff4a CACHE STRING "vita-head
 set(TOOLCHAIN_TAG eacff34d18e9872a78c0e520e1997ef71900ebb4 CACHE STRING "vita-toolchain branch, commit id or tag")
 set(PTHREAD_TAG 11d2e5722d98c86f33c908fc47b2cf6e55205db5 CACHE STRING "pthread-embedded branch, commit id or tag")
 set(VDPM_TAG v0.1.3 CACHE STRING "vdpm branch, commit id or tag")
-set(VITA_MAKEPKG_TAG 32f863c2a58a801b7d5a0296bdbbb443c9676e08 CACHE STRING "vita-makepkg branch, commit id or tag")
+set(VITA_MAKEPKG_TAG bbd1b18731cf8b6a69a18c9acdefd79a5b8c36eb CACHE STRING "vita-makepkg branch, commit id or tag")


### PR DESCRIPTION
Moves `VITA_MAKEPKG_TAG` from `32f863c` to [`bbd1b18`](https://github.com/vitasdk/vita-makepkg/commit/bbd1b18731cf8b6a69a18c9acdefd79a5b8c36eb) — [vitasdk/vita-makepkg#12](https://github.com/vitasdk/vita-makepkg/pull/12), two commits.

**The fix.** `PACMAN` defaulted to `$VITASDK/bin/pacman`. The client is not there and never has been: `vdpm` installs it at `libexec/vdpm/pacman`, deliberately off `PATH` so a Linux distribution's own pacman stays reachable as plain `pacman` — the reason is written next to the `#define` in `vdpm/src/vdpm.c`. Without `PACMAN` set, `PACMAN_PATH` resolved to nothing and the first thing needing the client died with `Cannot find the VitaSDK package client: …/bin/pacman`, exit 126.

Nothing in this repository hit it, because the core build passes a `PACMAN` of its own. What hit it is anybody building a recipe by hand against an installed SDK.

**And a test that had gone quiet.** `32f863c` stopped `run_pacman` passing `--noscriptlet` on queries, because pacman 7.1 rejects it there. Three assertions over the recorded arguments still spelled out the old invocation, so `tests/test-dependency-resolution.sh` had been failing on that repository ever since — silently, at a bare `grep` under `set -e`, printing nothing at all. The first commit of #12 corrects them and adds the check from the other side, so the rule is watched rather than merely established.

## Why this is a hand-move

`vita-makepkg` sits in the `untracked` half of `cmake/pin-tracking.json`, with its reason attached:

> a reviewed revision; its packaging assumptions are load-bearing for the core package

Which is exactly what changed here, so it moves when somebody has read it. The bot is not the right instrument for this pin, and I have not moved it into `tracked`.

The matching pin in `vitasdk/vitasdk-autobuild` (`VITA_MAKEPKG_REF` in `vitasdk_autobuild/config.py`, for the supervisor, which runs on a bare runner) moves in its own pull request.

## Checked

`describe` reads the pin at the committed revision, and it picks this up:

```
vita-makepkg: bbd1b18731cf8b6a69a18c9acdefd79a5b8c36eb
build_id:     sha256:5c075f93abe50e7cc4abb77c52909ddd7d02b679cc0e59f1d83efbf3c2a1d91a
```

All 9 CI tests and 6 protocol tests pass locally. The build itself is what CI is for: this changes a component that goes into every core package, so every packaged host rebuilds it.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).