### PR TITLE
Build a revision once, not once per repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,12 @@ jobs:
   # because its macOS leg had never run the code that publishes one.
   build:
     needs: describe
+    # Not on a push to master: that push is announced to autobuilds, which
+    # describes the same revision, builds the same lock through the same
+    # reusable workflow, and publishes what comes out. Building it here as
+    # well is the same ten legs twice, and the copy that says whether the
+    # revision is releasable is the one over there.
+    if: github.event_name != 'push' || github.ref != 'refs/heads/master'
     uses: ./.github/workflows/build-sdk.yml
     with:
       lock: ${{ needs.describe.outputs.lock }}

--- a/tests/ci/test-single-matrix.sh
+++ b/tests/ci/test-single-matrix.sh
@@ -67,6 +67,63 @@ for runner in sorted({host["runner"] for host in hosts} - {"ubuntu-24.04"}):
         print(f"build.yml names the runner {runner!r}; cmake/hosts.json is where runners are declared")
 if "cmake/toolchains/" in text:
     print("build.yml names a cross toolchain file; build-host.sh is where a host is built")
+
+# And it must not run that one path twice. A push to master is announced to
+# autobuilds, which describes the same revision and builds the same lock, so
+# building it here too is the same legs over again.
+def evaluate(expression, context):
+    tokens = re.findall(r"'[^']*'|\|\||&&|==|!=|[A-Za-z0-9_.-]+", expression)
+    position = 0
+
+    def take():
+        nonlocal position
+        position += 1
+        return tokens[position - 1]
+
+    def primary():
+        token = take()
+        if token.startswith("'"):
+            return token[1:-1]
+        value = context
+        for part in token.split("."):
+            value = value.get(part, "") if isinstance(value, dict) else ""
+        return value
+
+    def comparison():
+        left = primary()
+        if position < len(tokens) and tokens[position] in ("==", "!="):
+            operator = take()
+            right = primary()
+            return left == right if operator == "==" else left != right
+        return left
+
+    def conjunction():
+        value = comparison()
+        while position < len(tokens) and tokens[position] == "&&":
+            take()
+            right = comparison()
+            value = right if value else value
+        return value
+
+    value = conjunction()
+    while position < len(tokens) and tokens[position] == "||":
+        take()
+        right = conjunction()
+        value = value if value else right
+    return value
+
+
+def runs_on(event_name, ref):
+    condition = str(jobs[caller].get("if", "")).strip()
+    if not condition:
+        return True
+    return bool(evaluate(condition, {"github": {"event_name": event_name, "ref": ref}}))
+
+
+if runs_on("push", "refs/heads/master"):
+    print("a push to master builds here as well as in autobuilds; that is the same lock twice")
+if not runs_on("pull_request", "refs/pull/1/merge"):
+    print("a pull request no longer builds, which is the only place this build is the signal")
 PYEOF
 )
 


### PR DESCRIPTION
A push to master here fires `dispatch-build.yml`, and `autobuilds` then describes that revision, builds the lock **through this repository's own `build-sdk.yml`**, and publishes what comes out.

Since #173 removed the hand-written matrix, the build this workflow runs on that same push is the same lock, the same ten legs, the same code. Twice, at the same time, in two repositories.

That was worth having while the two were different paths — two paths give two signals, and the gap between them is exactly what #173 was about. They are one path now, so the second run is only cost. Four full builds were in flight at once this afternoon:

| run | revision |
|---|---|
| `buildscripts` master `Build` | `93a4d9a23` |
| `autobuilds` `Build SDK snapshots` (announced) | `93a4d9a23` |
| `buildscripts` #174 `Build` | the pin bump |
| `buildscripts` #170 `Build` | the dependabot bump |

Half of that is a copy of the other half.

## What changes

```yaml
  build:
    needs: describe
    if: github.event_name != 'push' || github.ref != 'refs/heads/master'
```

Only a push to master. Every pull request still builds — that is where the build is the signal that decides whether something merges, and it is the only place this workflow's build ever was one. A push to a branch with no pull request open still builds too.

On master the signal moves to the autobuilds run, which is strictly the better one: it applies the required-host policy and says whether the revision is releasable, which this workflow could never do.

`package-tests` needs `build`, so it follows it. Everything that reaches master reaches it through a pull request that ran both. The exception is the pin bot, which pushes to master directly — and a pin bump changes no packaging script, while `checks` still runs on every push either way.

## Test

`tests/ci/test-single-matrix.sh` gains the question, evaluated rather than matched as text — a small reader for the subset of the expression language a job condition uses, then:

- a push to master must not build here
- a pull request must still build

Against `master`'s `build.yml` it says so:

```
FAIL: a push to master builds here as well as in autobuilds; that is the same lock twice
```

All 9 CI tests and 6 protocol tests pass; `actionlint` is clean.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).