### PR TITLE
Embed the vdpm that can list the channels it names

### DIFF
--- a/cmake/Components.cmake
+++ b/cmake/Components.cmake
@@ -108,5 +108,5 @@ set(SAMPLES_TAG fe8fbef570f3280586c0c20157146e3faefb2181 CACHE STRING "samples b
 set(HEADERS_TAG 5e1e7d38d766e4c1634a77f6e5249caab8c8f9cb CACHE STRING "vita-headers branch, commit id or tag")
 set(TOOLCHAIN_TAG eacff34d18e9872a78c0e520e1997ef71900ebb4 CACHE STRING "vita-toolchain branch, commit id or tag")
 set(PTHREAD_TAG 11d2e5722d98c86f33c908fc47b2cf6e55205db5 CACHE STRING "pthread-embedded branch, commit id or tag")
-set(VDPM_TAG v0.1.3 CACHE STRING "vdpm branch, commit id or tag")
+set(VDPM_TAG v0.1.4 CACHE STRING "vdpm branch, commit id or tag")
 set(VITA_MAKEPKG_TAG bbd1b18731cf8b6a69a18c9acdefd79a5b8c36eb CACHE STRING "vita-makepkg branch, commit id or tag")


### PR DESCRIPTION
`VDPM_TAG` moves from `v0.1.3` to [`v0.1.4`](https://github.com/vitasdk/vdpm/releases/tag/v0.1.4), cut for this.

Two things the core has been shipping broken.

**`vdpm channels` could not run on Windows.** `include/list-channels.ps1` looked for `vdpm-channel.exe` in `bin/`; the bootstrap installs it under `share/vdpm/msys/usr/bin/`. What makes it sharper than a missing file is where you arrive from: that is the command vdpm's own error message sends you to when you do not name a series. The way out of the error was the error.

```
v0.1.3   $channelTool = Join-Path $sdkRoot "bin/vdpm-channel.exe"
v0.1.4   $channelTool = Join-Path $sdkRoot "share/vdpm/msys/usr/bin/vdpm-channel.exe"
```

**`refresh-repositories.{sh,ps1}` still defaulted to `stable`.** Which is not a series, so it 404s. The frontend refuses without a name; both helpers walked straight past that when run directly — which is what anybody following a written procedure does. The vdpm-side commit repaired the test covering it first: it ran the helper under `sh`, and on any machine where `/bin/sh` is dash it died at `set -o pipefail` before reaching the name check, so every name passed and the test reported OK having tested nothing.

Also in this tag: `host-triplet` recognising musl and FreeBSD, surviving `pipefail`, and agreeing with Windows about its patterns; and the bootstrap naming the real failure when no seed serves the detected host.

## Why this is a hand-move

`vdpm` sits in the `untracked` half of `cmake/pin-tracking.json`:

> a released tag; the vdpm release process moves it, and the core embeds the matching bundle

So the release comes first and the pin follows. `v0.1.4` is published and out of draft: nine host bundles, uploaded, downloaded back and `diff -ru`'d before undrafting, with `vdpm-0.1.4-x86_64-w64-mingw32.tar.bz2` among them — the one carrying the fix.

## What CI actually checks here

`scripts/ci/build-host.sh` downloads `vdpm-0.1.4-<host>.tar.bz2` for every packaged host and verifies it against the release's own sidecar rather than a hash pinned here, so a bundle that did not publish, or published wrong, fails the leg that needs it. The bootstrap smoke test then installs it and runs `vdpm --help`, `pacman --version` and `arm-vita-eabi-gcc --version` out of the result, wherever the host can run its own output.

That is the check that matters for a pin like this, and it only exists on the real build.

All 9 CI tests and 6 protocol tests pass locally.

---
AI tools were used in preparing this PR (Claude Opus 5, Anthropic).