### PR TITLE
Build the softfp shims with the compiler that exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,12 @@ if(NOT VITASDK_TARGET_ONLY)
     include(cmake/recipes/BuildHostTools.cmake)
 endif()
 include(cmake/recipes/BuildGccFinal.cmake)
+# After the compiler: the wrappers are assembled with it. Stage 2 imports the
+# archives already spliced and builds no components, so there is nothing to
+# splice there.
+if(NOT VITASDK_STAGE1_DIR)
+    include(cmake/recipes/SoftfpShims.cmake)
+endif()
 include(cmake/recipes/Provenance.cmake)
 
 # What the target half is made of, named once because two things wait for it:

--- a/cmake/recipes/BuildSdkComponents.cmake
+++ b/cmake/recipes/BuildSdkComponents.cmake
@@ -25,30 +25,6 @@ ExternalProject_add(vita-headers
     ${UPDATE_DISCONNECTED_SUPPORT}
     )
 
-# The softfp world calls the same hard-float Sce* stubs vita-headers just
-# installed, but with float/double arguments and return values sitting in
-# the wrong registers (AAPCS-base vs AAPCS-VFP). Splice the 23 shims from
-# softfp-shim/ into the affected stub archives in place -- see
-# PLAN-softfp.md, "Fase 1 - los 23 shims de serie" and
-# scripts/patch-softfp-stub-archives.sh for why this is an archive rewrite
-# and not a -lvita_softfp_shim added to LIB_SPEC.
-if(VITASDK_FLOAT_ABI STREQUAL "softfp")
-    add_custom_command(
-        OUTPUT ${CMAKE_BINARY_DIR}/softfp-shim.stamp
-        COMMAND ${PROJECT_SOURCE_DIR}/scripts/build-softfp-shim.sh
-            ${binutils_prefix}-gcc ${binutils_prefix}-ar ${binutils_prefix}-objcopy
-            ${PROJECT_SOURCE_DIR}/softfp-shim
-            ${CMAKE_INSTALL_PREFIX}/${target_arch}/include
-            ${CMAKE_INSTALL_PREFIX}/${target_arch}/lib
-            ${toolchain_build_install_dir}/${target_arch}/lib
-        COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/softfp-shim.stamp
-        DEPENDS vita-headers gcc-base binutils_${build_suffix}
-        COMMENT "Splicing the softfp ABI shims into the stub archives"
-        VERBATIM
-        )
-    add_custom_target(softfp-shim ALL DEPENDS ${CMAKE_BINARY_DIR}/softfp-shim.stamp)
-endif()
-
 ExternalProject_Add(newlib
     DEPENDS binutils_${target_suffix} vita-headers
     GIT_REPOSITORY ${NEWLIB_REPOSITORY}

--- a/cmake/recipes/SoftfpShims.cmake
+++ b/cmake/recipes/SoftfpShims.cmake
@@ -1,0 +1,36 @@
+#
+# Copyright(c) 2016 codestation
+# Distributed under the MIT License (http://opensource.org/licenses/MIT)
+#
+
+# The softfp world calls the same hard-float Sce* stubs vita-headers just
+# installed, but with float/double arguments and return values sitting in the
+# wrong registers (AAPCS-base vs AAPCS-VFP). Splice the 23 shims from
+# softfp-shim/ into the affected stub archives in place -- see PLAN-softfp.md,
+# "Fase 1 - los 23 shims de serie" and scripts/patch-softfp-stub-archives.sh
+# for why this is an archive rewrite and not a -lvita_softfp_shim added to
+# LIB_SPEC.
+#
+# Its own file because it has to be included after the compiler that
+# assembles the wrappers exists. It used to depend on the base compiler the
+# staged pipeline stopped building, and the dangling name went unnoticed until
+# the target was first asked for.
+
+include_guard(GLOBAL)
+
+if(VITASDK_FLOAT_ABI STREQUAL "softfp")
+    add_custom_command(
+        OUTPUT ${CMAKE_BINARY_DIR}/softfp-shim.stamp
+        COMMAND ${PROJECT_SOURCE_DIR}/scripts/build-softfp-shim.sh
+            ${binutils_prefix}-gcc ${binutils_prefix}-ar ${binutils_prefix}-objcopy
+            ${PROJECT_SOURCE_DIR}/softfp-shim
+            ${CMAKE_INSTALL_PREFIX}/${target_arch}/include
+            ${CMAKE_INSTALL_PREFIX}/${target_arch}/lib
+            ${toolchain_build_install_dir}/${target_arch}/lib
+        COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/softfp-shim.stamp
+        DEPENDS vita-headers ${gcc_final_barrier} binutils_${build_suffix}
+        COMMENT "Splicing the softfp ABI shims into the stub archives"
+        VERBATIM
+        )
+    add_custom_target(softfp-shim DEPENDS ${CMAKE_BINARY_DIR}/softfp-shim.stamp)
+endif()

--- a/tests/cmake/target-half-dependencies.cmake
+++ b/tests/cmake/target-half-dependencies.cmake
@@ -44,6 +44,24 @@ expect_absent("cmake/recipes/ExportSysroot.cmake" "softfp-shim"
 expect_absent("cmake/recipes/FinalizeSdk.cmake" "softfp-shim"
     "FinalizeSdk.cmake names softfp-shim itself instead of taking the list")
 
+# The wrappers are assembled with the target compiler, so the recipe has to be
+# included after whatever builds it. It named gcc-base, which the staged
+# pipeline stopped building, and the dangling dependency went unnoticed until
+# the target was first asked for -- make reported "No rule to make target
+# 'gcc-base'" and took the whole sysroot with it.
+expect_absent("cmake/recipes/SoftfpShims.cmake" "gcc-base"
+    "the shim recipe still names gcc-base, which nothing builds")
+expect_contains("cmake/recipes/SoftfpShims.cmake" "\${gcc_final_barrier}"
+    "the shim recipe does not wait for the compiler that assembles it")
+
+file(READ "${repository_root}/CMakeLists.txt" cmakelists)
+string(FIND "${cmakelists}" "include(cmake/recipes/BuildGccFinal.cmake)" gcc_at)
+string(FIND "${cmakelists}" "include(cmake/recipes/SoftfpShims.cmake)" shim_at)
+if(shim_at LESS gcc_at)
+    message(SEND_ERROR
+        "FAIL: the shim recipe is included before the compiler it needs")
+endif()
+
 # A softfp world whose shims were never spliced is a toolchain that
 # miscompiles quietly, so the list carries them exactly when the world is one.
 expect_contains("CMakeLists.txt"


### PR DESCRIPTION
The shim command depended on `gcc-base`. The staged pipeline builds no such target — it goes binutils and vita-headers, then newlib, then `gcc-final` — so asking for the shims failed with

```
No rule to make target 'gcc-base', needed by 'softfp-shim.stamp'
```

and took the sysroot with it. The dependency has been dangling since this was rebased onto the staged pipeline. Nothing reached the target until #179 made the export wait for it, so nothing said so.

It now waits for `gcc_final_barrier`. That is a variable, not yet set where the command used to live, so the recipe moves to `cmake/recipes/SoftfpShims.cmake`, included after `BuildGccFinal`. Stage 2 does not include it: it imports the archives already spliced and builds no components.

The test checks the recipe names no compiler that is not built, that it waits for the one that is, and that it is included after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)