### PR TITLE
Name the softfp world so makepkg can build in it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(NOT VITASDK_FLOAT_ABI STREQUAL "hard" AND NOT VITASDK_FLOAT_ABI STREQUAL "sof
     message(FATAL_ERROR "VITASDK_FLOAT_ABI must be 'hard' or 'softfp', got '${VITASDK_FLOAT_ABI}'")
 endif()
 if(VITASDK_FLOAT_ABI STREQUAL "softfp")
-    set(world_arch "vita-softfp")
+    set(world_arch "vita_softfp")
 else()
     set(world_arch "vita")
 endif()

--- a/cmake/Profiles.cmake
+++ b/cmake/Profiles.cmake
@@ -1,10 +1,20 @@
 include_guard(GLOBAL)
 
 # Published profile (world) names; describe rejects anything else.
-set(VITASDK_PROFILES vita vita-softfp)
+set(VITASDK_PROFILES vita vita_softfp)
 
 # The float ABI each profile bakes into the toolchain. A profile is a world and
 # a world is named by the architecture its packages carry, so the name is the
 # same on both sides of the build.
 set(VITASDK_PROFILE_FLOAT_ABI_vita hard)
-set(VITASDK_PROFILE_FLOAT_ABI_vita-softfp softfp)
+set(VITASDK_PROFILE_FLOAT_ABI_vita_softfp softfp)
+
+# makepkg builds shell variable names from CARCH (depends_$CARCH), so a world
+# whose name is not an identifier corrupts them and then aborts the build.
+foreach(profile IN LISTS VITASDK_PROFILES)
+    if(NOT profile MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+        message(FATAL_ERROR
+            "profile '${profile}' is not a valid shell identifier; makepkg "
+            "expands depends_${profile} and friends")
+    endif()
+endforeach()

--- a/scripts/validate-core-package.sh
+++ b/scripts/validate-core-package.sh
@@ -61,7 +61,7 @@ if [[ $pkgname == vitasdk-core ]]; then
 		exit 1
 	}
 
-	# The world (vita, vita-softfp, ...) is stamped in two independent places;
+	# The world (vita, vita_softfp, ...) is stamped in two independent places;
 	# a mismatch means the build tagged the release for one world while
 	# actually configuring the toolchain, or makepkg, for another.
 	world_from_version=$(bsdtar -xOf "$package" version_info.txt |

--- a/tests/ci/test-build-host-args.sh
+++ b/tests/ci/test-build-host-args.sh
@@ -140,9 +140,9 @@ run_build_host \
 	--host x86_64-linux-gnu --stage 1 \
 	--artifacts-dir "$temporary_directory/artifacts-6" --out-dir "$temporary_directory/out-6" \
 	--build-id sha256:test --version 0.1.1 --revision "$revision" \
-	--profile vita-softfp --packaged false >/dev/null 2>&1 || true
+	--profile vita_softfp --packaged false >/dev/null 2>&1 || true
 
-grep -qx -- '-DVITASDK_PROFILE=vita-softfp' "$recorded" || {
+grep -qx -- '-DVITASDK_PROFILE=vita_softfp' "$recorded" || {
 	printf 'stage 1 did not pass the profile to cmake:\n%s\n' "$(cat "$recorded")" >&2
 	exit 1
 }

--- a/tests/protocol/test-describe-lock.sh
+++ b/tests/protocol/test-describe-lock.sh
@@ -33,7 +33,7 @@ second_run=$(describe --profile vita --revision "$base_rev")
 base_build_id=$(field build_id <<< "$first_run")
 
 # Changing the profile changes build_id, same revision.
-softfp_build_id=$(describe --profile vita-softfp --revision "$base_rev" | field build_id)
+softfp_build_id=$(describe --profile vita_softfp --revision "$base_rev" | field build_id)
 [[ $base_build_id != "$softfp_build_id" ]] || {
 	printf 'build_id did not change when the profile changed\n' >&2
 	exit 1


### PR DESCRIPTION
No package can be built in the softfp world today. The first attempt was this morning — `32e026c` in vitasdk-autobuild put softfp in the try-build matrix — and both packages tried since died the same way before compiling anything:

```
vita-makepkg: line 381: unset: `provides_vita-softfp': not a valid identifier
==> ERROR: An unknown error has occurred. Exiting...
```

## Why

`merge_arch_attrs()` in makepkg builds shell variable names out of `CARCH`:

```bash
for attr in "${supported_attrs[@]}"; do
    eval "$attr+=(\"\${${attr}_$CARCH[@]}\")"
done
unset -v "${supported_attrs[@]/%/_$CARCH}"
```

A hyphen makes that name unusable, and bash does not say so — it reads `${provides_vita-softfp[@]}` as `${provides_vita-...}`: the variable `provides_vita`, the `-` default-value operator, and the word `softfp[@]`.

```
$ CARCH=vita-softfp; provides=(); eval "provides+=(\"\${provides_$CARCH[@]}\")"
$ printf 'provides=[%s]\n' "${provides[@]}"
provides=[softfp[@]]
$ unset -v "provides_$CARCH"
bash: unset: `provides_vita-softfp': not a valid identifier
```

So the literal string `softfp[@]` lands in all seven arrays — `provides`, `conflicts`, `depends`, `replaces`, `optdepends`, `makedepends`, `checkdepends` — and then the `unset` fails and makepkg aborts.

The abort is the lucky part. Without it every softfp package would have shipped with a fabricated `depends=softfp[@]`.

pacman assumes architectures are identifiers and never says so: `x86_64`, `aarch64`, `armv7h`, `i686` — nobody had reached for a hyphen.

## What changes

The world is `vita_softfp`, and `Profiles.cmake` now refuses any profile name that would break the same way. The tag, repository and channel names are separate fields and keep their hyphens.

The published softfp core has `CARCH="vita-softfp"` stamped in `bin/makepkg.conf`, so it has to be rebuilt — it is a nightly, and nothing has been built against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)